### PR TITLE
Update version number and indentation

### DIFF
--- a/docs/pipelines/tasks/deploy/azure-app-service-settings.md
+++ b/docs/pipelines/tasks/deploy/azure-app-service-settings.md
@@ -53,7 +53,7 @@ steps:
     appName: $(WebApp_Name)
     package: $(System.DefaultWorkingDirectory)/**/*.zip
 
-- task: AzureAppServiceSettings@0
+- task: AzureAppServiceSettings@1
   displayName: Azure App Service Settings
   inputs:
     azureSubscription: $(azureSubscription)
@@ -86,7 +86,7 @@ steps:
           "slotSetting": false
         }
       ]
-  connectionStrings: |
+    connectionStrings: |
       [
         {
           "name": "MysqlCredentials",


### PR DESCRIPTION
With version @0 we get "an error occurred while loading the yaml build pipeline. wrong number of segments"
From https://github.com/microsoft/azure-pipelines-tasks/blob/1765eed1fd4fbef2022e72a959810c67ac745c26/Tasks/AzureAppServiceSettingsV1/package.json
The current version is 1.

Also fixed indentation on connectionStrings part.