### PR TITLE
#4108 Add demand that dotnet required to generate report

### DIFF
--- a/docs/pipelines/tasks/test/publish-code-coverage-results.md
+++ b/docs/pipelines/tasks/test/publish-code-coverage-results.md
@@ -32,7 +32,7 @@ in the pipeline.
 
 ## Demands
 
-[none]
+To generate the HTML code coverage report you need dotnet 2.0.0 or later on the agent. The dotnet folder needs to be in the environment path. If there are multiple folders containing dotnet, the one with version 2.0.0. needs to be before any others in the path list.
 
 ::: moniker range="> tfs-2018"
 

--- a/docs/pipelines/tasks/test/publish-code-coverage-results.md
+++ b/docs/pipelines/tasks/test/publish-code-coverage-results.md
@@ -32,7 +32,7 @@ in the pipeline.
 
 ## Demands
 
-To generate the HTML code coverage report you need dotnet 2.0.0 or later on the agent. The dotnet folder needs to be in the environment path. If there are multiple folders containing dotnet, the one with version 2.0.0. needs to be before any others in the path list.
+To generate the HTML code coverage report you need dotnet 2.0.0 or later on the agent. The dotnet folder needs to be in the environment path. If there are multiple folders containing dotnet, the one with version 2.0.0 must be before any others in the path list.
 
 ::: moniker range="> tfs-2018"
 


### PR DESCRIPTION
dotnet 2.0.0 is required to generate report. 
It also needs to be in the path, to be found by task-lib.where. If there was documentation on task-lib.where then a link to that would explain how location for dotnet is resolved.