### PR TITLE
Add missing parameters

### DIFF
--- a/docs/pipelines/tasks/includes/yaml/DownloadPipelineArtifactV2.md
+++ b/docs/pipelines/tasks/includes/yaml/DownloadPipelineArtifactV2.md
@@ -14,4 +14,6 @@
     #artifact: # Optional
     #patterns: '**' # Optional
     #path: '$(Pipeline.Workspace)' 
+    #includeRootFolder: true
+    #replaceExistingArchive: true
 ```


### PR DESCRIPTION
I added missing `includeRootFolder` and `replaceExistingArchive` parameters to [Download Pipeline Artifacts task documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-pipeline-artifact?view=azure-devops).