### PR TITLE
Adding .net 4.6.2 or higher as the prereq for vstest & ptr task documentation

### DIFF
--- a/docs/pipelines/tasks/test/publish-test-results.md
+++ b/docs/pipelines/tasks/test/publish-test-results.md
@@ -51,6 +51,11 @@ produced when running tests to Azure Pipelines or TFS in order to obtain coverag
 The task supports popular coverage result formats such as [Cobertura](https://cobertura.github.io/cobertura/)
 and [JaCoCo](https://www.eclemma.org/jacoco/).
 
+## Check prerequisites
+
+If you are using windows self hosted agent, Make sure your machine has these prerequisites:
+- [.NET Framework](https://docs.microsoft.com/dotnet/framework/install/) 4.6.2 or higher
+
 <a name="demands"></a>
 
 ## Demands

--- a/docs/pipelines/tasks/test/publish-test-results.md
+++ b/docs/pipelines/tasks/test/publish-test-results.md
@@ -53,7 +53,8 @@ and [JaCoCo](https://www.eclemma.org/jacoco/).
 
 ## Check prerequisites
 
-If you are using windows self hosted agent, Make sure your machine has these prerequisites:
+If you are using a windows self-hosted agent, ensure your machine has the following prerequisite:
+
 - [.NET Framework](https://docs.microsoft.com/dotnet/framework/install/) 4.6.2 or higher
 
 <a name="demands"></a>

--- a/docs/pipelines/tasks/test/publish-test-results.md
+++ b/docs/pipelines/tasks/test/publish-test-results.md
@@ -53,9 +53,9 @@ and [JaCoCo](https://www.eclemma.org/jacoco/).
 
 ## Check prerequisites
 
-If you are using a windows self-hosted agent, ensure your machine has the following prerequisite:
+If you're using a Windows self-hosted agent, be sure that your machine has this prerequisite installed:
 
-- [.NET Framework](https://docs.microsoft.com/dotnet/framework/install/) 4.6.2 or higher
+- [.NET Framework](https://docs.microsoft.com/dotnet/framework/install/) 4.6.2 or a later version
 
 <a name="demands"></a>
 

--- a/docs/pipelines/tasks/test/vstest.md
+++ b/docs/pipelines/tasks/test/vstest.md
@@ -25,6 +25,11 @@ Tests that target the .NET core framework can be executed by specifying the appr
 
 Tests can be distributed on multiple agents using version 2 of this task. For more information, see [Run tests in parallel using the Visual Studio Test task](../../test/parallel-testing-vstest.md).
 
+## Check prerequisites
+
+If you are using windows self hosted agent, Make sure your machine has these prerequisites:
+- [.NET Framework](https://docs.microsoft.com/dotnet/framework/install/) 4.6.2 or higher
+
 ## Demands 
 
 The agent must have the following capability:

--- a/docs/pipelines/tasks/test/vstest.md
+++ b/docs/pipelines/tasks/test/vstest.md
@@ -27,7 +27,8 @@ Tests can be distributed on multiple agents using version 2 of this task. For mo
 
 ## Check prerequisites
 
-If you are using windows self hosted agent, Make sure your machine has these prerequisites:
+If you are using a windows selfihosted agent, esure your machine has the following prerequisite:
+
 - [.NET Framework](https://docs.microsoft.com/dotnet/framework/install/) 4.6.2 or higher
 
 ## Demands 

--- a/docs/pipelines/tasks/test/vstest.md
+++ b/docs/pipelines/tasks/test/vstest.md
@@ -27,9 +27,9 @@ Tests can be distributed on multiple agents using version 2 of this task. For mo
 
 ## Check prerequisites
 
-If you are using a windows selfihosted agent, esure your machine has the following prerequisite:
+If you're using a Windows self-hosted agent, be sure that your machine has this prerequisite installed:
 
-- [.NET Framework](https://docs.microsoft.com/dotnet/framework/install/) 4.6.2 or higher
+- [.NET Framework](https://docs.microsoft.com/dotnet/framework/install/) 4.6.2 or a later version
 
 ## Demands 
 


### PR DESCRIPTION
**Why?**

We made a change in December 2019 to build our client OM targeting .NET 4.6.2 instead of .NET 4.5. VSTest task uses Client OM and as result it stopped working on build agents where .NET 4.6.2 or above is not installed.

Fixes [AB#1710963](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1710963)