### PR TITLE
Adding a Note about fetching before merging

### DIFF
--- a/docs/repos/git/pulling.md
+++ b/docs/repos/git/pulling.md
@@ -188,7 +188,7 @@ When working in a branch, you may want to incorporate the latest changes from th
 #### [Visual Studio](#tab/visual-studio/)
 
 > [!NOTE]
-> The `git pull origin master` command combines `git fetch` and `git merge` commands. To do this properly in Visual Studio integation, you will need to **Sync** in **Team Explorer** to do the `fetch` part. This ensures your local git repository is up to date with its remote origin. 
+> The `git pull origin master` command combines `git fetch` and `git merge` commands. To do this properly in Visual Studio integration, you will need to **Sync** in **Team Explorer** to do the `fetch` part. This ensures your local git repository is up to date with its remote origin. 
 
 To merge the latest changes from the master branch to your branch:
 

--- a/docs/repos/git/pulling.md
+++ b/docs/repos/git/pulling.md
@@ -187,6 +187,9 @@ When working in a branch, you may want to incorporate the latest changes from th
 
 #### [Visual Studio](#tab/visual-studio/)
 
+> [!NOTE]
+> The `git pull origin master` command combines `git fetch` and `git merge` commands. To do this properly in Visual Studio integation, you will need to **Sync** in **Team Explorer** to do the `fetch` part. This ensures your local git repository is up to date with its remote origin. 
+
 To merge the latest changes from the master branch to your branch:
 
 1. In Team Explorer, select the **Home** button and choose **Branches**.


### PR DESCRIPTION
This was brought up in this tweet: https://twitter.com/jerrynixon/status/1232720988187451392?s=20

The Visual Studio instructions do not say anything about fetching remote changes before merging.

I'm not married to the wording, so if there's a better way to say this, please comment (and fix any grammatical issues!)