### PR TITLE
Fix paths relative to SVN prefix

### DIFF
--- a/docs/repos/git/perform-migration-from-svn-to-git.md
+++ b/docs/repos/git/perform-migration-from-svn-to-git.md
@@ -128,7 +128,7 @@ In this step, you will create a bare repository and make its default branch matc
     ```
     git init --bare c:\new-bare.git
     cd c:\new-bare.git
-    git symbolic-ref HEAD refs/heads/trunk
+    git symbolic-ref HEAD refs/heads/svn/trunk
     ```
 
 2. Push the local Git repository to the new bare Git repository
@@ -145,7 +145,7 @@ Your main development branch will be named "trunk", which matches the name it wa
    
     ```
     cd c:\new-bare.git
-    git branch -m trunk master
+    git branch -m svn/trunk master
     ```
 4. Clean up branches and tags
 git-svn makes all of Subversions tags into very-short branches in Git of the form "tags/name". You'll want to convert all those branches into actual Git tags or delete them.
@@ -154,7 +154,7 @@ git-svn makes all of Subversions tags into very-short branches in Git of the for
 
 ```
 cd c:\new-bare.git
-git for-each-ref --format='%(refname)' refs/heads/tags | % { $_.Replace('refs/heads/tags/','') } | % { git tag $_ "refs/heads/tags/$_"; git branch -D "tags/$_" }
+git for-each-ref --format='%(refname)' refs/heads/svn/tags | % { $_.Replace('refs/heads/svn/tags/','') } | % { git tag $_ "refs/heads/svn/tags/$_"; git branch -D "svn/tags/$_" }
 ```
 
 ## Advanced migrations


### PR DESCRIPTION
Added 'svn' prefix on three commands on the migration process. Without it, the process will fail.