### PR TITLE
Fix reference to `phpunit` script

### DIFF
--- a/docs/pipelines/ecosystems/php.md
+++ b/docs/pipelines/ecosystems/php.md
@@ -76,7 +76,7 @@ To use Composer to install dependencies, add the following snippet to your `azur
 To run tests with phpunit, add the following snippet to your `azure-pipelines.yml` file.
 
 ```yaml
-- script: phpunit
+- script: ./phpunit
   displayName: 'Run tests with phpunit'
 ```
 


### PR DESCRIPTION
In order for the pipeline to run the `phpunit` binary pulled in with Composer in the [pipelines-php](https://github.com/MicrosoftDocs/pipelines-php) repo, we need to reference the `phpunit` shell script in the root of the repo.

This accompanies https://github.com/MicrosoftDocs/pipelines-php/pull/3

#4011