### PR TITLE
adding note on gatekeeper alerts

### DIFF
--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -74,6 +74,17 @@ You can install the agent on Linux, macOS, or Windows machines. For more informa
 
 ::: moniker-end
 
+> [!NOTE]
+> On macOS you need to clear the special attribute on the download archive in order to prevent Gatekeeper protection displaying for each assembly in the tar file when `./config.sh` is run. The following command clears the extended attribute on the file.
+
+```bash
+xattr -c vsts-agent-osx-x64-V.v.v.tar.gz  ## replace V.v.v with the version in the filename downloaded.
+
+# then unpack the gzip tar file normally:
+
+tar xvfz vsts-agent-osx-x64-V.v.v.tar.gz
+```
+
 After you've installed the agent on a machine, you can install any other software on that machine as required by your jobs.
 
 ::: moniker range="azure-devops"

--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -75,15 +75,15 @@ You can install the agent on Linux, macOS, or Windows machines. For more informa
 ::: moniker-end
 
 > [!NOTE]
-> On macOS you need to clear the special attribute on the download archive in order to prevent Gatekeeper protection displaying for each assembly in the tar file when `./config.sh` is run. The following command clears the extended attribute on the file.
-
-```bash
-xattr -c vsts-agent-osx-x64-V.v.v.tar.gz  ## replace V.v.v with the version in the filename downloaded.
-
-# then unpack the gzip tar file normally:
-
-tar xvfz vsts-agent-osx-x64-V.v.v.tar.gz
-```
+> On macOS, you need to clear the special attribute on the download archive to prevent Gatekeeper protection from displaying for each assembly in the tar file when `./config.sh` is run. The following command clears the extended attribute on the file:
+>
+> ```bash
+> xattr -c vsts-agent-osx-x64-V.v.v.tar.gz  ## replace V.v.v with the version in the filename downloaded.
+> 
+> # then unpack the gzip tar file normally:
+> 
+> tar xvfz vsts-agent-osx-x64-V.v.v.tar.gz
+> ```
 
 After you've installed the agent on a machine, you can install any other software on that machine as required by your jobs.
 

--- a/docs/pipelines/agents/v2-osx.md
+++ b/docs/pipelines/agents/v2-osx.md
@@ -83,6 +83,8 @@ After you get a feel for how agents work, or if you want to automate setting up 
 
 1. Follow the instructions on the page.
 
+1. Clear extended attribute on the tar file -- `xattr -c vsts-agent-osx-x64-V.v.v.tar.gz`
+
 1. Unpack the agent into the directory of your choice. `cd` to that directory and run `./config.sh`. Make sure that the path to the directory contains no spaces because tools and scripts don't always properly escape spaces.
 
 ::: moniker-end
@@ -105,6 +107,8 @@ After you get a feel for how agents work, or if you want to automate setting up 
 
 1. Follow the instructions on the page.
 
+1. Clear extended attribute on the tar file -- `xattr -c vsts-agent-osx-x64-V.v.v.tar.gz`
+
 1. Unpack the agent into the directory of your choice. `cd` to that directory and run `./config.sh`. Make sure that the path to the directory contains no spaces because tools and scripts don't always properly escape spaces.
 
 ::: moniker-end
@@ -126,6 +130,8 @@ After you get a feel for how agents work, or if you want to automate setting up 
 1. Click the **Download** button.
 
 1. Follow the instructions on the page.
+
+1. Clear extended attribute on the tar file -- `xattr -c vsts-agent-osx-x64-V.v.v.tar.gz`
 
 1. Unpack the agent into the directory of your choice. `cd` to that directory and run `./config.sh`. Make sure that the path to the directory contains no spaces because tools and scripts don't always properly escape spaces.
 

--- a/docs/pipelines/agents/v2-osx.md
+++ b/docs/pipelines/agents/v2-osx.md
@@ -83,7 +83,7 @@ After you get a feel for how agents work, or if you want to automate setting up 
 
 1. Follow the instructions on the page.
 
-1. Clear extended attribute on the tar file -- `xattr -c vsts-agent-osx-x64-V.v.v.tar.gz`
+1. Clear the extended attribute on the tar file: `xattr -c vsts-agent-osx-x64-V.v.v.tar.gz`.
 
 1. Unpack the agent into the directory of your choice. `cd` to that directory and run `./config.sh`. Make sure that the path to the directory contains no spaces because tools and scripts don't always properly escape spaces.
 
@@ -107,7 +107,7 @@ After you get a feel for how agents work, or if you want to automate setting up 
 
 1. Follow the instructions on the page.
 
-1. Clear extended attribute on the tar file -- `xattr -c vsts-agent-osx-x64-V.v.v.tar.gz`
+1. Clear the extended attribute on the tar file: `xattr -c vsts-agent-osx-x64-V.v.v.tar.gz`.
 
 1. Unpack the agent into the directory of your choice. `cd` to that directory and run `./config.sh`. Make sure that the path to the directory contains no spaces because tools and scripts don't always properly escape spaces.
 
@@ -131,7 +131,7 @@ After you get a feel for how agents work, or if you want to automate setting up 
 
 1. Follow the instructions on the page.
 
-1. Clear extended attribute on the tar file -- `xattr -c vsts-agent-osx-x64-V.v.v.tar.gz`
+1. Clear the extended attribute on the tar file: `xattr -c vsts-agent-osx-x64-V.v.v.tar.gz`.
 
 1. Unpack the agent into the directory of your choice. `cd` to that directory and run `./config.sh`. Make sure that the path to the directory contains no spaces because tools and scripts don't always properly escape spaces.
 


### PR DESCRIPTION
on macOS gatekeeper protection presents
a dialog box for every single assembly loaded
when laucnhing config.sh - by issueing the
xattr command to clear the special attribute
on the downloaded archive this prevents
that constant dialog. see https://github.com/microsoft/azure-pipelines-agent/issues/2457

and https://github.com/microsoft/azure-pipelines-agent/issues/2457#issuecomment-548661284