### PR TITLE
Fix Azure DevOps Service feed locator url

### DIFF
--- a/docs/artifacts/how-to/set-up-upstream-sources.md
+++ b/docs/artifacts/how-to/set-up-upstream-sources.md
@@ -48,7 +48,7 @@ Selecting this option now means your feed will be configured to find and use pac
 1. From your feed page, go to **Feed settings** by clicking the gear icon
 2. On the **Upstream sources** tab, if you don't have any upstream sources you will see the below dialog where you can choose _Add upstream source_. If you do already have upstreams, you can select _Add upstream source_ in the top menu.
 3. In the **Add a new upstream source** dialog, choose _Azure Artifacts feed in another organization_
-4. Enter the **Azure DevOps Services feed locator**, this is just `azure-feed://` followed by the organization name, feed name, and the view that is shared. For example: `azure-feed://myOrg/myFeed@local`
+4. Enter the **Azure DevOps Services feed locator**, this is just `azure-feed://` followed by the organization name, project name, feed name, and the view that is shared. For example: `azure-feed://myOrg/myProject/myFeed@local`
 5. Select the package types you want to use and click _Add_.
 
 ## Consuming NuGet packages from upstream sources


### PR DESCRIPTION
Related to this AzureDevOps Bug: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1706611

It was discovered that the feed locator URI was incorrect, as well as the documentation.