### PR TITLE
Add GitHub Enterprise &Bitbucket as a supported Code Repo

### DIFF
--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -14,7 +14,7 @@ monikerRange: azure-devops
 
 A resource is anything used by a pipeline that lives outside the pipeline. Any of these can be pipeline resources:
 * CI/CD pipeline that produces artifacts (Azure Pipelines, Jenkins, etc.)
-* code repositories (GitHub, GitHub Enterprise, Azure Repos, Bitbucket Cloud, Git)
+* code repositories (Azure Repos Git repos, GitHub, GitHub Enterprise, Bitbucket Cloud)
 * container image registries (Azure Container Registry, Docker Hub, etc.) 
 * package feeds (Azure Artifact feed, Artifactory package etc.)  
 

--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -14,7 +14,7 @@ monikerRange: azure-devops
 
 A resource is anything used by a pipeline that lives outside the pipeline. Any of these can be pipeline resources:
 * CI/CD pipeline that produces artifacts (Azure Pipelines, Jenkins, etc.)
-* code repositories (GitHub, Azure Repos, Git)
+* code repositories (GitHub, GitHub Enterprise, Azure Repos, Bitbucket Cloud, Git)
 * container image registries (Azure Container Registry, Docker Hub, etc.) 
 * package feeds (Azure Artifact feed, Artifactory package etc.)  
 


### PR DESCRIPTION
Further down in the doc, it suggests that GitHub Enterprise and Bitbucket Cloud are supported as a Code Repo.