### PR TITLE
Corrected runOnce strategy example

### DIFF
--- a/docs/pipelines/process/deployment-jobs.md
+++ b/docs/pipelines/process/deployment-jobs.md
@@ -386,7 +386,7 @@ While executing deployment strategies, you can access output variables across jo
     name: echovar
 ```
 
-For a `runOnce` job you specify the name of the job instead of the lifecycle hook.
+For a `runOnce` job, specify the name of the job instead of the lifecycle hook:
 
 ```yaml
 # Set an output variable in a lifecycle hook of a deployment job executing runOnce strategy
@@ -414,4 +414,5 @@ For a `runOnce` job you specify the name of the job instead of the lifecycle hoo
   - script: "echo $(myVarFromDeploymentJob)"
     name: echovar
 ```
-Learn more on how to [set a multi-job output variable](https://docs.microsoft.com/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-a-multi-job-output-variable)
+
+Learn more about how to [set a multi-job output variable](https://docs.microsoft.com/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-a-multi-job-output-variable)


### PR DESCRIPTION
Corrected output variables schema for runOnce strategy and added an example.

It previously indicated that one should use the `lifecycle-hookname` to access output variables in another job. This is in fact false and the example from [this document](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-a-multi-job-output-variable) shows the correct implementation.

Ref: https://stackoverflow.com/questions/61476512/azure-devops-pipeline-define-variable-in-deployment-and-reuse-in-subsequent-job/61477357#61477357