### PR TITLE
Fix Minor typo for 'minor' run number. Resolves Issue #8074

### DIFF
--- a/docs/pipelines/process/expressions.md
+++ b/docs/pipelines/process/expressions.md
@@ -541,7 +541,7 @@ steps:
     echo "This is the major run number: $MAJOR_RUN"
     
     MINOR_RUN=$(echo $BUILD_BUILDNUMBER | cut -d '.' -f2)
-    echo "This is the major run number: $MINOR_RUN"
+    echo "This is the minor run number: $MINOR_RUN"
     
     # create pipeline variables
     echo "##vso[task.setvariable variable=major]$MAJOR_RUN"


### PR DESCRIPTION
This typo is found in https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions.

At the bottom of the page, there is an example for setting variables using bash. The following:

```MINOR_RUN=$(echo $BUILD_BUILDNUMBER | cut -d '.' -f2) echo "This is the major run number: $MINOR_RUN"```

should be:

```MINOR_RUN=$(echo $BUILD_BUILDNUMBER | cut -d '.' -f2) echo "This is the minor run number: $MINOR_RUN"```