### PR TITLE
Change link for k6/load impact

### DIFF
--- a/docs/test/load-test/overview.md
+++ b/docs/test/load-test/overview.md
@@ -95,7 +95,7 @@ Other open-source alternatives that support code-based tests are [Artillery](htt
 
 In addition, extensions from several load test vendors such as [SOASTA](https://marketplace.visualstudio.com/items?itemName=SOASTA.SOASTA-Extension)
 (now Akamai CloudTest), [Apica Loadtest](https://marketplace.visualstudio.com/items?itemName=apicasystem.apica-loadtest), and
-[Load Impact](https://marketplace.visualstudio.com/items?itemName=julienstroheker.loadimpact) are available in the Azure DevOps and Azure marketplace.
+[k6](https://marketplace.visualstudio.com/items?itemName=k6.k6-load-test) are available in the Azure DevOps and Azure marketplace.
 
 
 ## Download load tests and results


### PR DESCRIPTION
Changes the unofficial Load Impact marketplace extension to the official k6 one.
Some additional background in the following blog post https://k6.io/blog/load-impact-rebranding-to-k6