### PR TITLE
Mention that Maven task overwrites MAVEN_OPTS

### DIFF
--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -283,6 +283,15 @@ steps:
 - script: mvn install -B -e
 ```
 
+If you are using a [Maven task](../tasks/build/maven.md), make sure to also pass the `MAVEN_OPTS` variable because it gets overwritten otherwise:
+
+```yaml
+- task: Maven@3
+  inputs:
+    mavenPomFile: 'pom.xml'
+    mavenOptions: '-Xmx3072m $(MAVEN_OPTS)'
+```
+
 ## .NET/NuGet
 
 If you use `PackageReferences` to manage NuGet dependencies directly within your project file and have `packages.lock.json` file(s), you can enable caching by setting the `NUGET_PACKAGES` environment variable to a path under `$(Pipeline.Workspace)` and caching this directory.


### PR DESCRIPTION
For the Maven task, the default for `mavenOpts` / `mavenOptions` is not to fall back to the environment variable but a fixed value of `-Xmx1024m`. Therefore the caching configuration does not work out of the box with the Maven task. This updates the documentation with an example for a workaround.