### PR TITLE
Add Python caching documentation

### DIFF
--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -367,7 +367,7 @@ steps:
 
 ## Python/pip
 
-For Python projects using pip or Poetry, override the `PIP_CACHE_DIR` environment variable. If you are using Poetry, replace `requirements.txt` in the `key` field with `poetry.lock`.
+For Python projects that use pip or Poetry, override the `PIP_CACHE_DIR` environment variable. If you use Poetry, in the `key` field, replace `requirements.txt` with `poetry.lock`.
 
 ### Example
 
@@ -390,7 +390,7 @@ steps:
 
 ## Python/Pipenv
 
-For Python projects using Pipenv, override the `PIPENV_CACHE_DIR` environment variable.
+For Python projects that use Pipenv, override the `PIPENV_CACHE_DIR` environment variable.
 
 ### Example
 

--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -365,29 +365,6 @@ steps:
 - script: yarn --frozen-lockfile
 ```
 
-## PHP/Composer
-
-For PHP projects using Composer, override the `COMPOSER_CACHE_DIR` [environment variable](https://getcomposer.org/doc/06-config.md#cache-dir) used by Composer.
-
-### Example
-
-```yaml
-variables:
-  COMPOSER_CACHE_DIR: $(Pipeline.Workspace)/.composer
-
-steps:
-- task: Cache@2
-  inputs:
-    key: 'composer | "$(Agent.OS)" | composer.lock'
-    restoreKeys: |
-      composer | "$(Agent.OS)"
-      composer
-    path: $(COMPOSER_CACHE_DIR)
-  displayName: Cache composer
-
-- script: composer install
-```
-
 ## Python/pip
 
 For Python projects using pip or Poetry, override the `PIP_CACHE_DIR` environment variable. If you are using Poetry, replace `requirements.txt` in the `key` field with `poetry.lock`.
@@ -432,6 +409,29 @@ steps:
   displayName: Cache pipenv packages
 
 - script: pipenv install
+```
+
+## PHP/Composer
+
+For PHP projects using Composer, override the `COMPOSER_CACHE_DIR` [environment variable](https://getcomposer.org/doc/06-config.md#cache-dir) used by Composer.
+
+### Example
+
+```yaml
+variables:
+  COMPOSER_CACHE_DIR: $(Pipeline.Workspace)/.composer
+
+steps:
+- task: Cache@2
+  inputs:
+    key: 'composer | "$(Agent.OS)" | composer.lock'
+    restoreKeys: |
+      composer | "$(Agent.OS)"
+      composer
+    path: $(COMPOSER_CACHE_DIR)
+  displayName: Cache composer
+
+- script: composer install
 ```
 
 ## Known issues and feedback

--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -388,6 +388,52 @@ steps:
 - script: composer install
 ```
 
+## Python/pip
+
+For Python projects using pip or Poetry, override the `PIP_CACHE_DIR` environment variable. If you are using Poetry, replace `requirements.txt` in the `key` field with `poetry.lock`.
+
+### Example
+
+```yaml
+variables:
+  PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+
+steps:
+- task: Cache@2
+  inputs:
+    key: 'python | "$(Agent.OS)" | requirements.txt'
+    restoreKeys: | 
+      python | "$(Agent.OS)"
+      python
+    path: $(PIP_PATH_CACHE)
+  displayName: Cache pip packages
+
+- script: pip install -r requirements.txt
+```
+
+## Python/Pipenv
+
+For Python projects using Pipenv, override the `PIPENV_CACHE_DIR` environment variable.
+
+### Example
+
+```yaml
+variables:
+  PIPENV_CACHE_DIR: $(Pipeline.Workspace)/.pipenv
+
+steps:
+- task: Cache@2
+  inputs:
+    key: 'python | "$(Agent.OS)" | Pipfile.lock'
+    restoreKeys: | 
+      python | "$(Agent.OS)"
+      python
+    path: $(PIPENV_PATH_CACHE)
+  displayName: Cache pipenv packages
+
+- script: pipenv install
+```
+
 ## Known issues and feedback
 
 If you experience problems enabling caching for your project, first check the list of [pipeline caching issues](https://github.com/microsoft/azure-pipelines-tasks/labels/Area%3A%20PipelineCaching) in the microsoft/azure-pipelines-tasks repo. If you don't see your issue listed, [create a new issue](https://github.com/microsoft/azure-pipelines-tasks/issues/new?labels=Area%3A%20PipelineCaching).

--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -405,7 +405,7 @@ steps:
     restoreKeys: | 
       python | "$(Agent.OS)"
       python
-    path: $(PIP_PATH_CACHE)
+    path: $(PIP_CACHE_DIR)
   displayName: Cache pip packages
 
 - script: pip install -r requirements.txt
@@ -428,7 +428,7 @@ steps:
     restoreKeys: | 
       python | "$(Agent.OS)"
       python
-    path: $(PIPENV_PATH_CACHE)
+    path: $(PIPENV_CACHE_DIR)
   displayName: Cache pipenv packages
 
 - script: pipenv install


### PR DESCRIPTION
In this pull request I've added documentation for caching dependencies for Python projects within Azure Pipelines. I've shown how to do it with pip and Pipenv, and included a side note about Poetry, as it is the same as pip.

I'm more than happy to implement any suggested changes.