### PR TITLE
Mention pipeline artifact tasks clearly in docs

### DIFF
--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -42,7 +42,7 @@ If you have an Azure Pipeline that produces artifacts, you can consume the artif
 
 In your resource definition, `pipeline` is a unique value that you can use to reference the pipeline resource later on. `source` is the name of the pipeline that produces an artifact. 
 
-For an alternative way to download pipelines see tasks in [Pipeline Artifacts](../artifacts/pipeline-artifacts.md).
+For an alternative way to download pipelines, see tasks in [Pipeline Artifacts](../artifacts/pipeline-artifacts.md).
 
 ## [Schema](#tab/schema)
 

--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -42,6 +42,8 @@ If you have an Azure Pipeline that produces artifacts, you can consume the artif
 
 In your resource definition, `pipeline` is a unique value that you can use to reference the pipeline resource later on. `source` is the name of the pipeline that produces an artifact. 
 
+For an alternative way to download pipelines see tasks in [Pipeline Artifacts](../artifacts/pipeline-artifacts.md).
+
 ## [Schema](#tab/schema)
 
 ```yaml


### PR DESCRIPTION
When looking into what are the options for getting artifacts from other pipelines in templates, it wasn't very clear that you could use the tasks instead of the resources too. 

I'm still unsure about what the difference between using resources vs tasks.