### PR TITLE
Link to azure-devops StackOverflow tag

### DIFF
--- a/docs/pipelines/test/includes/help-and-support-footer.md
+++ b/docs/pipelines/test/includes/help-and-support-footer.md
@@ -10,5 +10,5 @@ ms.date: 02/19/2020
 ## Help and support
 
 Report any problems on [Developer Community](https://developercommunity.visualstudio.com),
-get advice on [Stack Overflow](https://stackoverflow.com/questions/tagged/vs-team-services),
+get advice on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-devops),
 and get support via our [Support](https://azure.microsoft.com/support/devops/) page.


### PR DESCRIPTION
Link to `azure-devops` StackOverflow tag instead of old `vs-team-services` tag