### PR TITLE
Fix typo in ##Ports section

### DIFF
--- a/docs/pipelines/process/service-containers.md
+++ b/docs/pipelines/process/service-containers.md
@@ -153,7 +153,7 @@ When specifying a container resource or an inline container, you can specify an 
 
 ```yaml
 resources:
-  container:
+  containers:
   - container: my_service
     image: my_service:latest
     ports:


### PR DESCRIPTION
Found while browsing the azure devops documentation

The following snippet is invalid:
```
resources:
  container:
```

Instead, this should be the following:
```
resources:
  containers:
```