### PR TITLE
Added clarification for the nuget package needed for Coverlet code coverage

### DIFF
--- a/docs/pipelines/ecosystems/dotnet-core.md
+++ b/docs/pipelines/ecosystems/dotnet-core.md
@@ -494,24 +494,24 @@ If you're building on Linux or macOS, you can use [Coverlet](https://github.com/
 Code coverage results can be published to the server by using the [Publish Code Coverage Results](../tasks/test/publish-code-coverage-results.md) task. To leverage this functionality, the coverage tool must be configured to generate results in Cobertura or JaCoCo coverage format.
 
 To run tests and publish code coverage with Coverlet:
-* Add a reference to the `coverlet.msbuild` NuGet package in your test project(s)
+* Add a reference to the `coverlet.msbuild` NuGet package in your test project(s).
 * Add this snippet to your `azure-pipelines.yml` file:
 
-```yaml
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet test'
-  inputs:
-    command: 'test'
-    arguments: '--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/Coverage/'
-    publishTestResults: true
-    projects: '**/test-library/*.csproj' # update with your test project directory
+  ```yaml
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet test'
+    inputs:
+      command: 'test'
+      arguments: '--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/Coverage/'
+      publishTestResults: true
+      projects: '**/test-library/*.csproj' # update with your test project directory
 
-- task: PublishCodeCoverageResults@1
-  displayName: 'Publish code coverage report'
-  inputs:
-    codeCoverageTool: 'Cobertura'
-    summaryFileLocation: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
-```
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Publish code coverage report'
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
+  ```
  
 ## Package and deliver your code
 

--- a/docs/pipelines/ecosystems/dotnet-core.md
+++ b/docs/pipelines/ecosystems/dotnet-core.md
@@ -493,7 +493,9 @@ If you're building on Linux or macOS, you can use [Coverlet](https://github.com/
 
 Code coverage results can be published to the server by using the [Publish Code Coverage Results](../tasks/test/publish-code-coverage-results.md) task. To leverage this functionality, the coverage tool must be configured to generate results in Cobertura or JaCoCo coverage format.
 
-To run tests and publish code coverage with Coverlet, add this snippet to your `azure-pipelines.yml` file:
+To run tests and publish code coverage with Coverlet:
+* Add a reference to the `coverlet.msbuild` NuGet package in your test project(s)
+* Add this snippet to your `azure-pipelines.yml` file:
 
 ```yaml
 - task: DotNetCoreCLI@2


### PR DESCRIPTION
When trying to get a Linux-based build for an ASP.NET Core web project (implementing IdentityServer4) and it took a while to figure out why I wasn't getting code coverage results published.  There are a few options for coverlet NuGet packages, and I mistakenly chose `coverlet.coverage`.  This change just adds a clarification that indicates the correct NuGet package to use to get this working.