### PR TITLE
Added documentation link to SiteConfig object for "general settings"

### DIFF
--- a/docs/pipelines/tasks/deploy/azure-app-service-settings.md
+++ b/docs/pipelines/tasks/deploy/azure-app-service-settings.md
@@ -26,7 +26,7 @@ The task works for ASP.NET, ASP.NET Core, PHP, Java, Python, Go and Node.js base
 |`resourceGroupName`<br/>Resource group|(Required) Name of the resource group|
 |`slotName`<br/>Slot|(Optional) Name of the slot<br/>Default value: `production`|
 |`appSettings`<br/>App settings|(Optional) Application settings to be entered using JSON syntax. Values containing spaces should be enclosed in double quotes.|
-|`generalSettings`<br/>General settings|(Optional) General settings to be entered using JSON syntax. Values containing spaces should be enclosed in double quotes.|
+|`generalSettings`<br/>General settings|(Optional) General settings to be entered using JSON syntax. Values containing spaces should be enclosed in double quotes. See the [App Service SiteConfig object documentation](https://docs.microsoft.com/azure/templates/microsoft.web/sites#siteconfig-object) for the available properties.|
 |`connectionStrings`<br/>Connection settings|(Optional) Connection strings to be entered using JSON syntax. Values containing spaces should be enclosed in double quotes.|
 
 Following is an example YAML snippet to deploy web application to the Azure Web App service running on windows.


### PR DESCRIPTION
It's not clear to customers what settings the "General Settings" object can contain, this links to the SiteConfig object which is ultimately patched by this task with the new "generalSettings".