### PR TITLE
Update allow-list-ip-url.md for Graph endpoint

### DIFF
--- a/docs/organizations/security/allow-list-ip-url.md
+++ b/docs/organizations/security/allow-list-ip-url.md
@@ -32,7 +32,7 @@ To ensure your organization works with any existing firewall or IP restrictions,
 - `https://login.microsoftonline.com`
 - `https://login.live.com`
 - `https://go.microsoft.com`
-- `https://graph.windows.net`
+- `https://graph.microsoft.com`
 - `https://app.vssps.dev.azure.com`
 - `https://app.vssps.visualstudio.com`
 - `https://aadcdn.msauth.net`


### PR DESCRIPTION
graph.windows.net will be deprecated and we need to start using graph.microsoft.com endpoint instead.