### PR TITLE
Update condition docs to cover cancelation

### DIFF
--- a/docs/pipelines/process/conditions.md
+++ b/docs/pipelines/process/conditions.md
@@ -55,7 +55,7 @@ stages:
       - script: echo Hello Stage A!
 
 - stage: B
-  condition: eq(variables.isMain, true)
+  condition: and(succeeded(), eq(variables.isMain, true))
   jobs:
   - job: B1
     steps:

--- a/docs/pipelines/process/expressions.md
+++ b/docs/pipelines/process/expressions.md
@@ -382,6 +382,7 @@ You can use the following status check functions as expressions in conditions, b
   * With no arguments, evaluates to `True` only if all previous jobs in the dependency graph succeeded or partially succeeded. 
   * If the previous job succeeded but a dependency further upstream failed, `succeeded('previousJobName')` will return true. When you just use `dependsOn: previousJobName`, it will fail because all of the upstream dependencies were not successful. To only evaluate the previous job, use `succeeded('previousJobName')` in a condition. 
   * With job names as arguments, evaluates to `True` if all of those jobs succeeded or partially succeeded.
+  * Evaluates to `False` if the pipeline is canceled.
 
 ### succeededOrFailed
 * For a step, equivalent to `in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')`


### PR DESCRIPTION
Call out that the succeeded function also
returns false when the pipeline is canceled.
Update the example using a variable in a condition
to reflect the best practice of combining it with
the succeeded function. The example as previously
written encouraged a pattern that leads to stages/jobs
executing even when the pipeline is canceled, which
is not usually what people want.