### PR TITLE
Fix up Git PAT examples

### DIFF
--- a/docs/repos/git/includes/personal-access-tokens.md
+++ b/docs/repos/git/includes/personal-access-tokens.md
@@ -135,7 +135,7 @@ On Linux or macOS, in Bash, you can enter:
  
 ```bash
 MY_PAT=yourPAT		# replace "yourPAT" with your actual PAT
-B64_PAT=$(echo "pat:$MY_PAT" | base64)
+B64_PAT=$(echo ":$MY_PAT" | base64)
 git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone https://dev.azure.com/yourOrgName/yourProjectName/_git/yourRepoName
 ```
 
@@ -143,7 +143,7 @@ On Windows, you can do something similar in PowerShell:
 
 ```powershell
 $MyPat = 'yourPAT'
-$B64Pat = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($MyPat))
+$B64Pat = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(":$MyPat"))
 git -c http.extraHeader="Authorization: Basic $B64Pat" clone https://dev.azure.com/yourOrgName/yourProjectName/_git/yourRepoName
 ```
 


### PR DESCRIPTION
The example as written did not work.

Use UTF8 instead of Unicode to get the
correct byte values in the PowerShell example.