### PR TITLE
Wrap GitHttpClient code samples in using(...)

### DIFF
--- a/docs/integrate/concepts/dotnet-client-libraries.md
+++ b/docs/integrate/concepts/dotnet-client-libraries.md
@@ -109,10 +109,11 @@ creds.Storage = new VssClientCredentialStorage();
 VssConnection connection = new VssConnection(new Uri(c_collectionUri), creds);
 
 // Get a GitHttpClient to talk to the Git endpoints
-GitHttpClient gitClient = connection.GetClient<GitHttpClient>();
-
-// Get data about a specific repository
-var repo = gitClient.GetRepositoryAsync(c_projectName, c_repoName).Result;
+using (GitHttpClient gitClient = connection.GetClient<GitHttpClient>())
+{
+    // Get data about a specific repository
+    var repo = gitClient.GetRepositoryAsync(c_projectName, c_repoName).Result;
+}
 ```
 
 Authentication paths that produce an interactive dialog are not available in the .NET Standard version of the .NET client libraries. When using the .NET Standard version of the .NET client libraries, you will need to provide credentials more explicitly in order to authenticate, as in the example below.
@@ -141,10 +142,11 @@ namespace ConsoleApp1
             VssConnection connection = new VssConnection(new Uri(c_collectionUri), creds);
 
             // Get a GitHttpClient to talk to the Git endpoints
-            GitHttpClient gitClient = connection.GetClient<GitHttpClient>();
-
-            // Get data about a specific repository
-            var repo = gitClient.GetRepositoryAsync(c_projectName, c_repoName).Result;
+            using (GitHttpClient gitClient = connection.GetClient<GitHttpClient>())
+            {
+                // Get data about a specific repository
+                var repo = gitClient.GetRepositoryAsync(c_projectName, c_repoName).Result;
+            }
         }
     }
 }


### PR DESCRIPTION
The documentation over at https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2013/dn413500(v=vs.120) is from 2014 and no longer updated. The base class VssHttpClientBase now implements IDisposable, so it's important to demonstrate proper usage of this object.