### PR TITLE
Tasks supported in agentless jobs

### DIFF
--- a/docs/pipelines/process/phases.md
+++ b/docs/pipelines/process/phases.md
@@ -307,6 +307,19 @@ You add a server job in the editor by selecting '...' on the **Pipeline** channe
 Server jobs are not supported in this version of TFS.
 ::: moniker-end
 
+<h3 id="agentless-tasks">Tasks supported in agentless jobs</h3>
+
+Currently only the following tasks are supported out of the box for agentless jobs:
+
+* [Delay task](../tasks/utility/delay.md)
+* [Invoke Azure function task](../tasks/utility/azure-function.md)
+* [Invoke REST API task](../pipelines/tasks/utility/http-rest-api.md)
+* [Publish To Azure Service Bus task](../pipelines/tasks/utility/publish-to-azure-service-bus.md)
+* [Query Azure Monitor Alerts task](../pipelines/tasks/utility/azure-monitor.md)
+* [Query Work Items task](../pipelines/tasks/utility/work-item-query.md)
+
+As tasks are extensible additional agentless tasks can be added through extensions.
+
 ---
 
 <h2 id="dependencies">Dependencies</h2>


### PR DESCRIPTION
fixes #4672

Added list of tasks offered in Azure DevOps in the Classic pipeline tab.