### PR TITLE
Changed depricated MochaDone to Mocha.Done in sample code

### DIFF
--- a/docs/extend/develop/add-build-task.md
+++ b/docs/extend/develop/add-build-task.md
@@ -322,7 +322,7 @@ tmr.run();
 Next, add the following example success test to your ```_suite.ts``` file to run the task mock runner:
 
 ```typescript
-it('should succeed with simple inputs', function(done: MochaDone) {
+it('should succeed with simple inputs', function(done: Mocha.Done) {
     this.timeout(1000);
 
     let tp = path.join(__dirname, 'success.js');
@@ -361,7 +361,7 @@ tmr.run();
 Next, add the following to your ```_suite.ts``` file to run the task mock runner:
 
 ```typescript
-it('it should fail if tool returns 1', function(done: MochaDone) {
+it('it should fail if tool returns 1', function(done: Mocha.Done) {
     this.timeout(1000);
 
     let tp = path.join(__dirname, 'failure.js');


### PR DESCRIPTION
MochaDone has been deprecated for a while and cannot be found when compiling. So I changed it to `Mocha.Done`.