### PR TITLE
Update scale-set-agents.md

### DIFF
--- a/docs/pipelines/agents/scale-set-agents.md
+++ b/docs/pipelines/agents/scale-set-agents.md
@@ -239,7 +239,7 @@ If you just want to create a scale set with the default 128GiB OS disk using a p
 
         Shutdown the VM
         ```azurecli
-        az vm shutdown --resource-group <myResourceGroup> --name <MyVM>
+        az vm stop --resource-group <myResourceGroup> --name <MyVM>
         ```
 
         Deallocate the VM


### PR DESCRIPTION
`az vm shutdown` isn't a command under `az vm`.  
`az vm stop` is likely what you want.

See https://docs.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-stop