### PR TITLE
Fix YAML in service connection webhook example

### DIFF
--- a/release-notes/2020/includes/pipelines/sprint-172-update.md
+++ b/release-notes/2020/includes/pipelines/sprint-172-update.md
@@ -62,8 +62,9 @@ steps:
 - task: PowerShell@2
   inputs:
     targetType: 'inline'
+    ### JSON payload data is available in the form of ${{ parameters.<WebhookAlias>.<JSONPath>}}
     script: |
-      Write-Host ${{ parameters.MyWebhookTrigger.repositoryName}} ### JSON payload data is available in the form of ${{ parameters.<WebhookAlias>.<JSONPath>}}
+      Write-Host ${{ parameters.MyWebhookTrigger.repositoryName}}
       Write-Host ${{ parameters.MyWebhookTrigger.component.group}}
 ```
 


### PR DESCRIPTION
Since the comment is in a multi-line inline code section, its not parsed correctly and throws the following error when trying the example 1:1:

`Encountered error(s) while parsing pipeline YAML:
/azure-pipelines.yml (Line: 14, Col: 13): Unexpected symbol: '<WebhookAlias>'. Located at position 12 within expression: parameters.<WebhookAlias>.<JSONPath>. For more help, refer to https://go.microsoft.com/fwlink/?linkid=842996`

Solution: move comment above section.

I did not find a way to make inline comments (e.g. powershell in this case) to work, so this was the best i could come up with.