### PR TITLE
Rephrasing description of agents

### DIFF
--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -21,7 +21,7 @@ monikerRange: '>= tfs-2015'
 To build your code or deploy your software using Azure Pipelines, you need at least one agent. As you add more code and people, you'll eventually need more.
 
 When your pipeline runs, the system begins one or more jobs.
-An agent is installable software that runs one job at a time.
+An agent is computing infrastructure that installs and runs software one job at a time.
 
 ::: moniker range=">= azure-devops-2019"
 Jobs can be run [directly on the host machine of the agent](../process/phases.md) or [in a container](../process/container-phases.md).

--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -21,7 +21,7 @@ monikerRange: '>= tfs-2015'
 To build your code or deploy your software using Azure Pipelines, you need at least one agent. As you add more code and people, you'll eventually need more.
 
 When your pipeline runs, the system begins one or more jobs.
-An agent is computing infrastructure that installs and runs software one job at a time.
+An agent is computing infrastructure with installed agent software that runs one job at a time.
 
 ::: moniker range=">= azure-devops-2019"
 Jobs can be run [directly on the host machine of the agent](../process/phases.md) or [in a container](../process/container-phases.md).

--- a/docs/pipelines/get-started/key-pipelines-concepts.md
+++ b/docs/pipelines/get-started/key-pipelines-concepts.md
@@ -29,7 +29,7 @@ Learn about the key concepts and components that are used in Azure Pipelines. Un
 
 ## Agent
 
-When your build or deployment runs, the system begins one or more jobs. An agent is installable software that runs one job at a time.
+When your build or deployment runs, the system begins one or more jobs. An agent is computing infrastructure that installs and runs software one job at a time.
 
 For more in-depth information about the different types of agents and how to use them, see [Build and release agents](../agents/agents.md).
 

--- a/docs/pipelines/get-started/key-pipelines-concepts.md
+++ b/docs/pipelines/get-started/key-pipelines-concepts.md
@@ -29,7 +29,7 @@ Learn about the key concepts and components that are used in Azure Pipelines. Un
 
 ## Agent
 
-When your build or deployment runs, the system begins one or more jobs. An agent is computing infrastructure that installs and runs software one job at a time.
+When your build or deployment runs, the system begins one or more jobs. An agent is computing infrastructure with installed agent software that runs one job at a time.
 
 For more in-depth information about the different types of agents and how to use them, see [Build and release agents](../agents/agents.md).
 


### PR DESCRIPTION
This PR rephrases the description of an agent which was a bit ambiguous from:

- An agent is installable software that runs one job at a time

to 

- An agent is computing infrastructure that installs and runs software one job at a time