### PR TITLE
Added indentation for JSON examples

### DIFF
--- a/docs/extend/develop/auth-schemes.md
+++ b/docs/extend/develop/auth-schemes.md
@@ -31,48 +31,48 @@ Default authentication header used is: "Basic {{ #base64 endpoint.username \":\"
 
 ```json
 {
-"id": "endpoint-auth-scheme-basic",
-"description": "Basic Authentication based endpoint authentication scheme",
-"type": "ms.vss-endpoint.service-endpoint-auth-scheme",
-"targets": [
-    "ms.vss-endpoint.endpoint-auth-schemes"
-],
-"properties": {
-    "name": "UsernamePassword",
-    "displayName": "i18n:Basic Authentication",
-    "headers": [
-        {
-            "name": "Authorization",
-            "value": "Basic {{ #base64 endpoint.username \":\" endpoint.password }}"
-        }
+    "id": "endpoint-auth-scheme-basic",
+    "description": "Basic Authentication based endpoint authentication scheme",
+    "type": "ms.vss-endpoint.service-endpoint-auth-scheme",
+    "targets": [
+        "ms.vss-endpoint.endpoint-auth-schemes"
     ],
-    "inputDescriptors": [
-        {
-            "id": "username",
-            "name": "i18n:Username",
-            "description": "i18n:Username for connecting to the endpoint",
-            "inputMode": "textbox",
-            "isConfidential": false,
-            "validation": {
-                "isRequired": true,
-                "dataType": "string",
-                 "maxLength": 300
+    "properties": {
+        "name": "UsernamePassword",
+        "displayName": "i18n:Basic Authentication",
+        "headers": [
+            {
+                "name": "Authorization",
+                "value": "Basic {{ #base64 endpoint.username \":\" endpoint.password }}"
             }
-        },
-        {   
-            "id": "password",
-            "name": "i18n:Password",
-            "description": "i18n:Password for connecting to the endpoint",
-            "inputMode": "passwordbox",
-            "isConfidential": true,
-            "validation": {
-                "isRequired": true,
-                "dataType": "string",
-                "maxLength": 300
+        ],
+        "inputDescriptors": [
+            {
+                "id": "username",
+                "name": "i18n:Username",
+                "description": "i18n:Username for connecting to the endpoint",
+                "inputMode": "textbox",
+                "isConfidential": false,
+                "validation": {
+                    "isRequired": true,
+                    "dataType": "string",
+                     "maxLength": 300
+                }
+            },
+            {   
+                "id": "password",
+                "name": "i18n:Password",
+                "description": "i18n:Password for connecting to the endpoint",
+                "inputMode": "passwordbox",
+                "isConfidential": true,
+                "validation": {
+                    "isRequired": true,
+                    "dataType": "string",
+                    "maxLength": 300
+                }
             }
-        }
-    ]
-}
+        ]
+    }
 }
 ```
 
@@ -84,36 +84,36 @@ Default authentication header used is: {{endpoint.apitoken}}
 
 ```json
 {
-"id": "endpoint-auth-scheme-token",
-"description": "i18n:Token based endpoint authentication scheme",
-"type": "ms.vss-endpoint.service-endpoint-auth-scheme",
-"targets": [
-    "ms.vss-endpoint.endpoint-auth-schemes"
-],
-"properties": {
-    "name": "Token",
-    "displayName": "i18n:Token Based Authentication",
-    "headers": [
-        {
-            "name": "Authorization",
-            "value": "{{endpoint.apitoken}}"
-        }
+    "id": "endpoint-auth-scheme-token",
+    "description": "i18n:Token based endpoint authentication scheme",
+    "type": "ms.vss-endpoint.service-endpoint-auth-scheme",
+    "targets": [
+        "ms.vss-endpoint.endpoint-auth-schemes"
     ],
-    "inputDescriptors": [
-        {
-            "id": "apitoken",
-            "name": "i18n:API Token",
-            "description": "i18n:API Token for connection to endpoint",
-            "inputMode": "textbox",
-            "isConfidential": true,
-            "validation": {
-                "isRequired": true,
-                "dataType": "string",
-                "maxLength": 300
+    "properties": {
+        "name": "Token",
+        "displayName": "i18n:Token Based Authentication",
+        "headers": [
+            {
+                "name": "Authorization",
+                "value": "{{endpoint.apitoken}}"
             }
-        }
-    ]
-}
+        ],
+        "inputDescriptors": [
+            {
+                "id": "apitoken",
+                "name": "i18n:API Token",
+                "description": "i18n:API Token for connection to endpoint",
+                "inputMode": "textbox",
+                "isConfidential": true,
+                "validation": {
+                    "isRequired": true,
+                    "dataType": "string",
+                    "maxLength": 300
+                }
+            }
+        ]
+    }
 }
 ```
 
@@ -125,29 +125,29 @@ The value of certificate has to be provided in the text area.
 
 ```json
 {
-"id": "endpoint-auth-scheme-cert",
-"description": "i18n:Creates a certificate-based endpoint authentication scheme",
-"type": "ms.vss-endpoint.service-endpoint-auth-scheme",
-"targets": [
-    "ms.vss-endpoint.endpoint-auth-schemes"
-],
-"properties": {
-    "name": "Certificate",
-    "displayName": "i18n:Certificate Based",
-    "inputDescriptors": [
-        {
-            "id": "certificate",
-            "name": "i18n:Certificate",
-            "description": "Content of the certificate",
-            "inputMode": "TextArea",
-            "isConfidential": true,
-            "validation": {
-                "isRequired": true,
-                "dataType": "string"
+    "id": "endpoint-auth-scheme-cert",
+    "description": "i18n:Creates a certificate-based endpoint authentication scheme",
+    "type": "ms.vss-endpoint.service-endpoint-auth-scheme",
+    "targets": [
+        "ms.vss-endpoint.endpoint-auth-schemes"
+    ],
+    "properties": {
+        "name": "Certificate",
+        "displayName": "i18n:Certificate Based",
+        "inputDescriptors": [
+            {
+                "id": "certificate",
+                "name": "i18n:Certificate",
+                "description": "Content of the certificate",
+                "inputMode": "TextArea",
+                "isConfidential": true,
+                "validation": {
+                    "isRequired": true,
+                    "dataType": "string"
+                }
             }
-        }
-    ]
-}
+        ]
+    }
 }
 ```
 
@@ -157,15 +157,15 @@ This scheme is used when an endpoint type doesn't require to take any input. For
 
 ```json
 {
-"id": "endpoint-auth-scheme-none",
-"description": "i18n:Creates an endpoint authentication scheme with no authentication.",
-"type": "ms.vss-endpoint.service-endpoint-auth-scheme-none",
-"targets": [
-    "ms.vss-endpoint.endpoint-auth-schemes"
-],
-"properties": {
-    "name": "None",
-    "displayName": "i18n:No Authentication"
-}
+    "id": "endpoint-auth-scheme-none",
+    "description": "i18n:Creates an endpoint authentication scheme with no authentication.",
+    "type": "ms.vss-endpoint.service-endpoint-auth-scheme-none",
+    "targets": [
+        "ms.vss-endpoint.endpoint-auth-schemes"
+    ],
+    "properties": {
+        "name": "None",
+        "displayName": "i18n:No Authentication"
+    }
 }
 ```


### PR DESCRIPTION
Added indenting for JSON example blocks. It was hard to read, so added some indenting to make it more readable.