### PR TITLE
Removing extra ">>" in the "Public Project"

### DIFF
--- a/docs/organizations/projects/toc.yml
+++ b/docs/organizations/projects/toc.yml
@@ -30,7 +30,7 @@
     href: ../public/make-project-public.md
   - name: Save project data
     href: save-project-data.md
-- name: Public projects >>
+- name: Public projects
   href: ../public/about-public-projects.md 
 
 


### PR DESCRIPTION
An extra ">>" is displayed in the toc 
![image](https://user-images.githubusercontent.com/5002831/88970341-4cf80600-d2c3-11ea-8e14-920aaf88b784.png)
