### PR TITLE
Pin the version of kubernetes in the deployment instructions so that kubernetes api changes won't break examples

### DIFF
--- a/docs/pipelines/ecosystems/kubernetes/aks-template.md
+++ b/docs/pipelines/ecosystems/kubernetes/aks-template.md
@@ -50,7 +50,8 @@ az aks create \
     --name myapp \
     --node-count 1 \
     --enable-addons monitoring \
-    --generate-ssh-keys
+    --generate-ssh-keys \
+    --kubernetes-version 1.16.10
 ```
 
 ## Sign in to Azure Pipelines


### PR DESCRIPTION
This is a proposed fix for #8987 

When following the instructions for [Build and deploy to Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/kubernetes/aks-template?view=azure-devops) even by following the instructions exactly it will cause a fail on deployment due to changes in the kubernetes api on newer version of AKS.

I am changing the docs here to pin a version so that future examples won't break, and have a separate PR to fix the actual code that deploys the example so it should succeed on more recent versions of kubernetes that can be seen in [this pr](https://github.com/microsoft/azure-pipelines-yaml/pull/509)
