### PR TITLE
Update docs to allow for SSL and non-SSL based examples

### DIFF
--- a/docs/integrate/how-to/call-rest-api.md
+++ b/docs/integrate/how-to/call-rest-api.md
@@ -88,22 +88,23 @@ Most samples on this site use Personal Access Tokens as they're a compact exampl
 
 ## TFS
 
-For TFS, `instance` is `{server:port}` and by default the port is 8080 for non-SSL connections.
-The default collection is `DefaultCollection`, but can be any collection.
+For TFS, `instance` is `{server:port}`. The default port for a non-SSL connection is 8080.
 
-Here's how to get a list of projects from TFS using the default port and collection across SSL.
+The default collection is `DefaultCollection`, but you can use any collection.
+
+Here's how to get a list of projects from TFS using the default port and collection across SSL:
 
 ```dos
 curl -u {username}[:{personalaccesstoken}] https://{server}/DefaultCollection/_apis/projects?api-version=2.0
 ```
 
-And across non-SSL connection
+To get the same list across a non-SSL connection:
 
 ```dos
 curl -u {username}[:{personalaccesstoken}] http://{server}:8080/DefaultCollection/_apis/projects?api-version=2.0
 ```
 
-The examples above use personal access tokens, which requires that you [create a personal access token](../../organizations/accounts/use-personal-access-tokens-to-authenticate.md).
+These examples use personal access tokens, which requires that you [create a personal access token](../../organizations/accounts/use-personal-access-tokens-to-authenticate.md).
 
 
 ## Responses

--- a/docs/integrate/how-to/call-rest-api.md
+++ b/docs/integrate/how-to/call-rest-api.md
@@ -88,13 +88,19 @@ Most samples on this site use Personal Access Tokens as they're a compact exampl
 
 ## TFS
 
-For TFS, `instance` is `{server:port}` and by default the port is 8080.
+For TFS, `instance` is `{server:port}` and by default the port is 8080 for non-SSL connections.
 The default collection is `DefaultCollection`, but can be any collection.
 
-Here's how to get a list of projects from TFS using the default port and collection.
+Here's how to get a list of projects from TFS using the default port and collection across SSL.
 
 ```dos
-curl -u {username}[:{personalaccesstoken}] https://{server}:8080/DefaultCollection/_apis/projects?api-version=2.0
+curl -u {username}[:{personalaccesstoken}] https://{server}/DefaultCollection/_apis/projects?api-version=2.0
+```
+
+And across non-SSL connection
+
+```dos
+curl -u {username}[:{personalaccesstoken}] http://{server}:8080/DefaultCollection/_apis/projects?api-version=2.0
 ```
 
 The examples above use personal access tokens, which requires that you [create a personal access token](../../organizations/accounts/use-personal-access-tokens-to-authenticate.md).


### PR DESCRIPTION
This documentation threw me for a loop because the examples were using port 8080 across https. That's not correct, so I'm making this change to allow for the non-SSL example with the port and the SSL example with default SSL port.