### PR TITLE
Fix minor typo in sprint-170-update.md

### DIFF
--- a/release-notes/2020/includes/pipelines/sprint-170-update.md
+++ b/release-notes/2020/includes/pipelines/sprint-170-update.md
@@ -20,7 +20,7 @@ To use scale set agents, you will first create a VM scale set in your Azure subs
 
 ### Ubuntu 20.04 in preview for Azure Pipelines hosted pools
 
-The Ubuntu 20.04 image is now available in preview for Azure Pipelines hosted pools. To use this image, update your YAML file to include vmImage:'ubuntu-20.04' . Please note, the ubuntu-latest image label will continue to point to ubuntu-18.04 until ubuntu-20.04 comes out of preview later this year.
+The Ubuntu 20.04 image is now available in preview for Azure Pipelines hosted pools. To use this image, update your YAML file to include vmImage: 'ubuntu-20.04' . Please note, the ubuntu-latest image label will continue to point to ubuntu-18.04 until ubuntu-20.04 comes out of preview later this year.
 
 Please note, since the ubuntu 20.04 image is in preview, it currently doesn't support all of the tooling available in ubuntu-18.04 . [Learn more](https://github.com/actions/virtual-environments/tree/master/images/linux)
 


### PR DESCRIPTION
Add missing space to yml example for ubuntu 20.0.4 preview. (Pipeline would fail without it and online validation still passes the yml.)