### PR TITLE
Fix word difference between azure devops and docs

### DIFF
--- a/docs/pipelines/ecosystems/includes/create-pipeline-before-template-selected.md
+++ b/docs/pipelines/ecosystems/includes/create-pipeline-before-template-selected.md
@@ -9,7 +9,7 @@ ms.date: 02/13/2020
 
 1. Sign in to your Azure DevOps organization and navigate to your project.
 
-2. Go to **Pipelines**, and then select **New Pipeline**.
+2. Go to **Pipelines**, and then select **Create Pipeline**.
 
 3. Walk through the steps of the wizard by first selecting **GitHub** as the location of your source code.
 
@@ -17,4 +17,4 @@ ms.date: 02/13/2020
 
 5. When the list of repositories appears, select your repository.
 
-6. You might be redirected to GitHub to install the Azure Pipelines app. If so, select **Approve and install**.
+6. You might be redirected to GitHub to install the Azure Pipelines app. If so, select **Approve & install**.


### PR DESCRIPTION
Fixes https://github.com/MicrosoftDocs/azure-devops-docs/issues/9053
Replace 'Create Pipeline' and 'Approve & install' with 'New Pipeline' and 'Approve and install'.