### PR TITLE
Fixed documentation ambiguity

### DIFF
--- a/docs/repos/tfvc/merge-command.md
+++ b/docs/repos/tfvc/merge-command.md
@@ -134,6 +134,12 @@ c:\projects>tf merge /candidate branch2 branch1 /recursive
 The following example discards changeset 137 as a candidate for merging into branch2.
 
 ```
+c:\projects>tf merge /discard /version:C137~C137 branch1 branch2 /recursive
+```
+
+The following example discards all the changesets up to changeset 137 as a candidate for merging into branch2.
+
+```
 c:\projects>tf merge /discard /version:C137 branch1 branch2 /recursive
 ```
 


### PR DESCRIPTION
I've tested this on my OnPrem deployment of tfs and it seems like this command merges the range of changesets into the destination if you provide multiple versionspecs. Otherwise all the changesets up to the specified will be merged. The /discard parameter has no effect on this. I've fixed the mix up and added an additional example to clear any possible confusion.
Related issues: #547 #6943 #8603