### PR TITLE
Changing the databricks version to trial

### DIFF
--- a/docs/pipelines/apps/cd/azure/build-data-pipeline.md
+++ b/docs/pipelines/apps/cd/azure/build-data-pipeline.md
@@ -174,7 +174,7 @@ To make commands easier to run, start by selecting a default region. After you s
         --resource-group $rgName \
         --name databricks-cicd-ws  \
         --location eastus2  \
-        --sku standard
+        --sku trial
     ```
   3. Copy the Subscription ID for your Databricks service to use later. 
 


### PR DESCRIPTION
With the standard version of databricks, you can't create the Key Vault-backed secret scope, you need a premium or trial version.

This is the error when you use the standard version:

Premium Tier is disabled in this workspace. Secret scopes can only be created with initial_manage_principal "users".