### PR TITLE
Added detailed description for user option values

### DIFF
--- a/docs/repos/tfvc/status-command.md
+++ b/docs/repos/tfvc/status-command.md
@@ -58,7 +58,7 @@ tf stat[us] itemspec [/collection:TeamProjectCollectionUrl]
 	<td><p>Specifies the shelveset that contains the changes you want to list.</p><p>This option cannot be combined with the <strong>/workspace</strong> option.</p></td></tr>
 <tr>
 	<td><p><strong>/user</strong></p></td>
-    <td><p>Lists all pending changes made by the specified user. An asterisk (<strong></strong></em>) symbol includes data about changes from all users. The default is the current user.</p><table><thead>
+    <td><p>Lists all pending changes made by the specified user. An asterisk (<strong></strong></em>) symbol includes data about changes from all users. The default is the current user.</p><p>Acceptable values for this option:</p><ul><li>username</li><li>useraccount</li><li>an asterisk</li></ul><table><thead>
 <tr><th><strong>Note</strong></th></tr></thead><tbody>
 <tr>
 	<td><p>See Remarks, below, for the limitations of this option.</p></td></tr></tbody></table></td></tr>


### PR DESCRIPTION
People seem to get confused by what name should be provided to the /user option. I provided more detailed explanation for what the possible values for this option are.
Related issue: #4882 