### PR TITLE
update uri (master->main) for scripts to generate agent vm

### DIFF
--- a/docs/pipelines/agents/scale-set-agents.md
+++ b/docs/pipelines/agents/scale-set-agents.md
@@ -112,7 +112,7 @@ In the following example, a new resource group and virtual machine scale set are
     Select any VM SKU and storage SKU.
 
     > [!NOTE]
-    > Licensing considerations limit us from distributing Microsoft-hosted images. We are unable to provide these images for you to use in your scale set agents. But, the [scripts](https://github.com/actions/virtual-environments/tree/master/images) that we use to generate these images are open source. You are free to use these scripts and create your own custom images.
+    > Licensing considerations limit us from distributing Microsoft-hosted images. We are unable to provide these images for you to use in your scale set agents. But, the [scripts](https://github.com/actions/virtual-environments/tree/main/images) that we use to generate these images are open source. You are free to use these scripts and create your own custom images.
 
 5. After creating your scale set, navigate to your scale set in the Azure portal and verify the following settings:
 
@@ -415,7 +415,7 @@ The Diagnostic tab shows all actions executed by Azure DevOps to Create, Delete,
 
 ### Where can I find the images used for Microsoft-hosted agents?
 
-Licensing considerations limit us from distributing Microsoft-hosted images. We are unable to provide these images for you to use in your scale set agents. But, the [scripts](https://github.com/actions/virtual-environments/tree/master/images) that we use to generate these images are open source. You are free to use these scripts and create your own custom images.
+Licensing considerations limit us from distributing Microsoft-hosted images. We are unable to provide these images for you to use in your scale set agents. But, the [scripts](https://github.com/actions/virtual-environments/tree/main/images) that we use to generate these images are open source. You are free to use these scripts and create your own custom images.
 
 ### How do I configure scale set agents to run UI tests?
 


### PR DESCRIPTION
The "master" branch is no longer, but it is now "main". Update the URI to the scripts for generating the VM images to reflect this.