### PR TITLE
[variables] Plain script with `task.setvariable` captures trailing quote

### DIFF
--- a/docs/pipelines/process/variables.md
+++ b/docs/pipelines/process/variables.md
@@ -72,7 +72,7 @@ steps:
       echo ${{ variables.one }} # outputs initialValue
       echo $(one)
     displayName: First variable pass
-  - script: echo '##vso[task.setvariable variable=one]secondValue'
+  - bash: echo '##vso[task.setvariable variable=one]secondValue'
     displayName: Set new variable value
   - script: |
       echo ${{ variables.one }} # outputs initialValue


### PR DESCRIPTION
This may well be a bug rather than a doc issue, but this seemed like the easiest way to report this.

See these two runs that show both a single and a double quote suffer from this problem:
* `--tag vfix-tag-name-on-stable-branch'` https://dev.azure.com/ms/react-native/_build/results?buildId=107643&view=logs&j=6bb1d585-fe16-5108-3aa2-8096d3b89a29&t=825e22fe-dd9a-57a0-9ccc-0792f895c3b3
* `--tag vfix-tag-name-on-stable-branch"` https://dev.azure.com/ms/react-native/_build/results?buildId=107644&view=logs&j=6bb1d585-fe16-5108-3aa2-8096d3b89a29&t=825e22fe-dd9a-57a0-9ccc-0792f895c3b3

Switching to bash did work as expected: https://dev.azure.com/ms/react-native/_build/results?buildId=107646&view=logs&j=6bb1d585-fe16-5108-3aa2-8096d3b89a29&t=c5c100de-91e7-5436-046b-560e02f23375