### PR TITLE
Update docker.md

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -226,7 +226,8 @@ Next, we'll create the Dockerfile.
             libcurl4 \
             libicu60 \
             libunwind8 \
-            netcat
+            netcat \
+            libssl1.0
 
     WORKDIR /azp
 


### PR DESCRIPTION
It expects version 1.0 or the agent can't start with this error: "No usable version of the libssl was found"

See: https://github.com/dotnet/runtime/issues/12747