### PR TITLE
Use valid archiveFilePatterns pattern

### DIFF
--- a/docs/pipelines/tasks/includes/yaml/ExtractFilesV1.md
+++ b/docs/pipelines/tasks/includes/yaml/ExtractFilesV1.md
@@ -12,7 +12,7 @@ ms.technology: devops-cicd-tasks
 # Extract a variety of archive and compression files such as .7z, .rar, .tar.gz, and .zip
 - task: ExtractFiles@1
   inputs:
-    #archiveFilePatterns: '*.zip' 
+    #archiveFilePatterns: '**/*.zip' 
     destinationFolder: 
     #cleanDestinationFolder: true 
 ```


### PR DESCRIPTION
`*.zip` is not a valid match pattern and should be replaced by `**/*.zip` (see https://github.com/microsoft/azure-pipelines-tasks/issues/13613)