### PR TITLE
Pipelines YAML Schema: publish/download displayName

### DIFF
--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -1973,6 +1973,7 @@ The task publishes (uploads) a file or folder as a pipeline artifact that other 
 steps:
 - publish: string # path to a file or folder
   artifact: string # artifact name
+  displayName: string  # friendly name to display in the UI
 ```
 
 # [Example](#tab/example)
@@ -1981,6 +1982,7 @@ steps:
 steps:
 - publish: $(Build.SourcesDirectory)/build
   artifact: WebApp
+  displayName: Publish artifact WebApp
 ```
 
 ---
@@ -1999,6 +2001,7 @@ steps:
 - download: [ current | pipeline resource identifier | none ] # disable automatic download if "none"
   artifact: string ## artifact name, optional; downloads all the available artifacts if not specified
   patterns: string # patterns representing files to include; optional
+  displayName: string  # friendly name to display in the UI
 ```
 ### Artifact download location
 
@@ -2018,6 +2021,7 @@ steps:
 - download: current  # refers to artifacts published by current pipeline
   artifact: WebApp
   patterns: '**/.js'
+  displayName: Download artifact WebApp
 - download: MyAppA   # downloads artifacts available as part of the pipeline resource
 ```
 


### PR DESCRIPTION
Added the displayName option that is also useable for the publish/download parts (synonyms for Publish/Download PipelineArtifact tasks).
Expected it to be documented.

It is mentioned on the detailed information page (https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml) to check the YAML Schema page for additional properties.

![image](https://user-images.githubusercontent.com/1635825/94908599-38421500-04a2-11eb-9705-97a6090d5b2a.png)
