### PR TITLE
Updates compatibility notes for ##vso[release.updatereleasename]

### DIFF
--- a/docs/pipelines/scripts/logging-commands.md
+++ b/docs/pipelines/scripts/logging-commands.md
@@ -477,7 +477,8 @@ Add a tag for current build.
 #### Usage
 
 Update the release name for the running release.
-Note: this is not supported in Azure DevOps Server or TFS.
+
+Note: Supported in Azure DevOps, and Azure DevOps Server as of version 2020.
 
 #### Example
 

--- a/docs/pipelines/scripts/logging-commands.md
+++ b/docs/pipelines/scripts/logging-commands.md
@@ -478,7 +478,8 @@ Add a tag for current build.
 
 Update the release name for the running release.
 
-Note: Supported in Azure DevOps, and Azure DevOps Server as of version 2020.
+> [!NOTE]
+> Supported in Azure DevOps and Azure DevOps Server beginning in version 2020.
 
 #### Example
 


### PR DESCRIPTION
`##vso[release.updatereleasename]` is supported as of Azure DevOps Server 2020.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoftdocs/azure-devops-docs/9489)
<!-- Reviewable:end -->
