### PR TITLE
Adding information on how to renew a client secret for auto generated SPN via service connection

### DIFF
--- a/docs/pipelines/release/azure-rm-endpoint.md
+++ b/docs/pipelines/release/azure-rm-endpoint.md
@@ -54,6 +54,7 @@ Errors that may occur when the system attempts to create the service connection 
 * [Failed to assign contributor role](#contributorrole)
 * [Some subscriptions are missing from the subscription drop down menu](#missingSubscriptions)
 * [Automatically created service principal secret has expired](#autoCreatedSecretExpiration)
+* [Failed to obtain the Json Web Token (JWT)](#failedToObtainJWT)
 
 <a name="privileges"></a>
 
@@ -189,6 +190,22 @@ An issue that often arises with automatically created service principals is that
 1. Click "Verify" on the service connection page. 
 
 1. Click "Save". The client secret for that service principal has now been renewed for 2 years.
+
+<a name="failedToObtainJWT"></a>
+
+### Failed to obtain the Json Web Token (JWT) using service principal client ID
+
+This issue occurs when trying to verify a service connection that has had a secret expired. To resolve this issue please do the below:
+
+1. Navigate to the ARM service connection in question
+
+1. Make a change to the service connection, the easiest and recommended way would be to add a description.
+
+1. Save the service connection (Note: save, do not try to verify).
+
+1. Exit out of the service connection, refresh the service connections page.
+
+1. Edit the service connection again, click "Verify". Save the service connection.
 
 ## What authentication mechanisms are supported? How do Managed Identities work?
 

--- a/docs/pipelines/release/azure-rm-endpoint.md
+++ b/docs/pipelines/release/azure-rm-endpoint.md
@@ -6,7 +6,7 @@ ms.assetid: B43E78DE-5D73-4303-981F-FB86D46F0CAE
 ms.topic: conceptual
 ms.author: ronai
 author: RoopeshNair
-ms.date: 09/09/2020
+ms.date: 10/15/2020
 monikerRange: '>= tfs-2015'
 ---
 
@@ -53,6 +53,7 @@ Errors that may occur when the system attempts to create the service connection 
 * [A valid refresh token was not found](#sessionexpired)
 * [Failed to assign contributor role](#contributorrole)
 * [Some subscriptions are missing from the subscription drop down menu](#missingSubscriptions)
+* [Automatically created service principal secret has expired](#autoCreatedSecretExpiration)
 
 <a name="privileges"></a>
 
@@ -174,6 +175,20 @@ To fix this issue you will need to modify the supported account types and who ca
 1. Under **Supported account types**, _Who can use this application or access this API?_ select **Accounts in any organizational directory**.
 
 1. Select **Save**.
+
+<a name="autoCreatedSecretExpiration"></a>
+
+### Automatically created Service Principal token is expired
+
+The recommended way to create a service connection in Azure Devops Services is through the "Automatic" method. This will create a service principal for you in the Azure Portal so you don't need to do so manually. An issue that often arises is that service principal's token will expire, and users have to create a new one. This isn't the case, and users can generate a new secret for that automatically created service principal. To do so, follow the steps below:
+
+1. Navigate to the ARM service connection that was created through the "Automatic" method.
+
+1. Click "Edit" in the top right of the page.
+
+1. Click "Verify" on the service connection page. 
+
+1. Click "Save". The client secret for that service principal has now been renewed for 2 years.
 
 ## What authentication mechanisms are supported? How do Managed Identities work?
 

--- a/docs/pipelines/release/azure-rm-endpoint.md
+++ b/docs/pipelines/release/azure-rm-endpoint.md
@@ -54,7 +54,7 @@ Errors that may occur when the system attempts to create the service connection 
 * [Failed to assign contributor role](#contributorrole)
 * [Some subscriptions are missing from the subscription drop down menu](#missingSubscriptions)
 * [Automatically created service principal secret has expired](#autoCreatedSecretExpiration)
-* [Failed to obtain the Json Web Token (JWT)](#failedToObtainJWT)
+* [Failed to obtain the JSON Web Token (JWT)](#failedToObtainJWT)
 
 <a name="privileges"></a>
 
@@ -181,31 +181,41 @@ To fix this issue you will need to modify the supported account types and who ca
 
 ### Automatically created service principal client secret is expired
 
-An issue that often arises with automatically created service principals is that the service principal's token expires and needs to be renewed. If you run into issues refreshing the token, check out [our other troubleshooting resolutions](#troubleshoot). Users can renew the token for automatically created service principals by following these steps:
+An issue that often arises with service principals that are automatically created is that the service principal's token expires and needs to be renewed. If you run into issues with refreshing the token, check out [our other troubleshooting resolutions](#troubleshoot). 
 
-1. Navigate to the ARM service connection that was created through the "Automatic" method.
+To renew the token for an automatically created service principal:
 
-1. Click "Edit" in the top right of the page.
+1. Go to the Azure Resource Manager service connection that was created by using the Automatic method.
 
-1. Click "Verify" on the service connection page. 
+1. In the upper-right corner, click **Edit**.
 
-1. Click "Save". The client secret for that service principal has now been renewed for 2 years.
+1. Click **Verify** on the service connection page. 
+
+1. Click **Save**. The client secret for that service principal has now been renewed for two years.
 
 <a name="failedToObtainJWT"></a>
 
-### Failed to obtain the Json Web Token (JWT) using service principal client ID
+### Failed to obtain the JSON Web Token (JWT) using service principal client ID
 
-This issue occurs when trying to verify a service connection that has had a secret expired. To resolve this issue please do the below:
+This issue occurs when you try to verify a service connection that has an expired secret.
 
-1. Navigate to the ARM service connection in question
+To resolve this issue:
 
-1. Make a change to the service connection, the easiest and recommended way would be to add a description.
+1. Go to the Azure Resource Manager service connection you want to update.
 
-1. Save the service connection (Note: save, do not try to verify).
+1. Make a change to the service connection. The easiest and recommended change would be to add a description.
 
-1. Exit out of the service connection, refresh the service connections page.
+1. Save the service connection.
+   > [!NOTE]
+   > Select **Save**. Don't try to verify at this step.
 
-1. Edit the service connection again, click "Verify". Save the service connection.
+1. Exit the service connection, and then refresh the service connections page.
+
+1. Edit the service connection again.
+
+1. Click **Verify**.
+
+1. Save the service connection.
 
 ## What authentication mechanisms are supported? How do Managed Identities work?
 

--- a/docs/pipelines/release/azure-rm-endpoint.md
+++ b/docs/pipelines/release/azure-rm-endpoint.md
@@ -180,7 +180,7 @@ To fix this issue you will need to modify the supported account types and who ca
 
 ### Automatically created service principal client secret is expired
 
-The recommended way to create a service connection in Azure Devops Services is through the "Automatic" method. This will create a service principal for you in the Azure Portal so you don't need to do so manually. An issue that often arises is that service principal's token will expire, and users have to create a new one. This isn't the case, and users can generate a new secret for that automatically created service principal. To do so, follow the steps below:
+An issue that often arises with automatically created service principals is that the service principal's token expires and needs to be renewed. Users can renew the token for automatically created service principals by following these steps::
 
 1. Navigate to the ARM service connection that was created through the "Automatic" method.
 

--- a/docs/pipelines/release/azure-rm-endpoint.md
+++ b/docs/pipelines/release/azure-rm-endpoint.md
@@ -180,7 +180,7 @@ To fix this issue you will need to modify the supported account types and who ca
 
 ### Automatically created service principal client secret is expired
 
-An issue that often arises with automatically created service principals is that the service principal's token expires and needs to be renewed. Users can renew the token for automatically created service principals by following these steps::
+An issue that often arises with automatically created service principals is that the service principal's token expires and needs to be renewed. If you run into issues refreshing the token, check out [our other troubleshooting resolutions](#troubleshoot). Users can renew the token for automatically created service principals by following these steps:
 
 1. Navigate to the ARM service connection that was created through the "Automatic" method.
 

--- a/docs/pipelines/release/azure-rm-endpoint.md
+++ b/docs/pipelines/release/azure-rm-endpoint.md
@@ -179,7 +179,7 @@ To fix this issue you will need to modify the supported account types and who ca
 
 <a name="autoCreatedSecretExpiration"></a>
 
-### Automatically created service principal client secret is expired
+### Automatically created service principal client secret has expired
 
 An issue that often arises with service principals that are automatically created is that the service principal's token expires and needs to be renewed. If you run into issues with refreshing the token, check out [our other troubleshooting resolutions](#troubleshoot). 
 
@@ -195,7 +195,7 @@ To renew the token for an automatically created service principal:
 
 <a name="failedToObtainJWT"></a>
 
-### Failed to obtain the JSON Web Token (JWT) using service principal client ID
+### Failed to obtain the JWT by using the service principal client ID
 
 This issue occurs when you try to verify a service connection that has an expired secret.
 
@@ -203,9 +203,10 @@ To resolve this issue:
 
 1. Go to the Azure Resource Manager service connection you want to update.
 
-1. Make a change to the service connection. The easiest and recommended change would be to add a description.
+1. Make a change to the service connection. The easiest and recommended change is to add a description.
 
 1. Save the service connection.
+
    > [!NOTE]
    > Select **Save**. Don't try to verify at this step.
 

--- a/docs/pipelines/release/azure-rm-endpoint.md
+++ b/docs/pipelines/release/azure-rm-endpoint.md
@@ -178,7 +178,7 @@ To fix this issue you will need to modify the supported account types and who ca
 
 <a name="autoCreatedSecretExpiration"></a>
 
-### Automatically created Service Principal token is expired
+### Automatically created service principal client secret is expired
 
 The recommended way to create a service connection in Azure Devops Services is through the "Automatic" method. This will create a service principal for you in the Azure Portal so you don't need to do so manually. An issue that often arises is that service principal's token will expire, and users have to create a new one. This isn't the case, and users can generate a new secret for that automatically created service principal. To do so, follow the steps below:
 


### PR DESCRIPTION
Many customers don't know that a client secret can be renewed for an auto generated SPN / service connection. The UI doesn't have a "secret" section for SPNs that were created using the "Automatic" method during the service connection creation process. It is as simple as clicking two buttons to renew the secret.

Added information on how to do this the ARM endpoint doc.