### PR TITLE
Specifying what a 'new user' is.

### DIFF
--- a/docs/organizations/security/restrict-invitations.md
+++ b/docs/organizations/security/restrict-invitations.md
@@ -8,14 +8,14 @@ ms.technology: devops-security
 ms.author: chcomley
 author: chcomley
 monikerRange: 'azure-devops'
-ms.date: 06/03/2020
+ms.date: 10/16/2020
 ---
 
 # Restrict new user invitations from Project and Team Administrators 
 
 [!INCLUDE [temp](../../includes/version-vsts-only.md)]
 
-By default, all administrators can invite new users to Azure DevOps. Disabling this policy will block Team and Project Administrators from inviting new users. Project Collection Administrators (PCAs) can add new users to the organization, regardless of the policy status.
+By default, all administrators can invite new users to their Azure DevOps organization. Disabling this policy will block Team and Project Administrators from inviting new users to the organization. Project Collection Administrators (PCAs) can add new users to the organization, regardless of the policy status. If a user is already a member of the organization, Project and Team Adminstrators will still be able to add that user to their project.
 
 <!---
 


### PR DESCRIPTION
Adding a 'new user' means at the org level. If this policy is on Team / Project admins wont be able to add new users to the ORG, but will still be able to add users to their projects if they already exist in the org.

Fixes https://github.com/MicrosoftDocs/azure-devops-docs/issues/9502