### PR TITLE
Fix wrong code sample in PAT

### DIFF
--- a/docs/repos/git/includes/personal-access-tokens.md
+++ b/docs/repos/git/includes/personal-access-tokens.md
@@ -135,7 +135,7 @@ On Linux or macOS, in Bash, you can enter:
  
 ```bash
 MY_PAT=yourPAT		# replace "yourPAT" with your actual PAT
-B64_PAT=$(echo ":$MY_PAT" | base64)
+B64_PAT=$(printf ":$MY_PAT" | base64)
 git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone https://dev.azure.com/yourOrgName/yourProjectName/_git/yourRepoName
 ```
 


### PR DESCRIPTION
The original code gives wrong encoded value because it has '\n' at last and Azure DevOps server doesn't treat trailing whitespace characters.
By replacing `echo` with `printf`, the string would contain no '\n' at last, fixing the issue.