### PR TITLE
Update get-status-badge.md

### DIFF
--- a/docs/pipelines/includes/get-status-badge.md
+++ b/docs/pipelines/includes/get-status-badge.md
@@ -33,7 +33,7 @@ Now with the badge Markdown in your clipboard, take the following steps in GitHu
 
 4. Notice that the status badge appears in the description of your repository.
 
-To configure anonymous access to badges for private repositories:
+To configure anonymous access to badges for private projects:
 
 1. Navigate to **Project Settings**
 

--- a/docs/pipelines/includes/get-status-badge.md
+++ b/docs/pipelines/includes/get-status-badge.md
@@ -33,7 +33,7 @@ Now with the badge Markdown in your clipboard, take the following steps in GitHu
 
 4. Notice that the status badge appears in the description of your repository.
 
-To configure anonymous access to badges:
+To configure anonymous access to badges for private repositories:
 
 1. Navigate to **Project Settings**
 


### PR DESCRIPTION
Clarify that the anonymous badge access setting is only available for private repositories.

This confused me as I created a public repository and do not see the setting. Another person also mentioned this on #7074 asking why they can't see it. The only reason I was looking for it is because I wanted to be _absolutely_ sure the badge would be visible to the public.