### PR TITLE
Add detail around collection admins

### DIFF
--- a/docs/organizations/accounts/azure-ad-tenant-policy-restrict-org-creation.md
+++ b/docs/organizations/accounts/azure-ad-tenant-policy-restrict-org-creation.md
@@ -20,7 +20,7 @@ Learn how to turn on the Azure Active Directory (Azure AD) tenant policy, which 
 
 ## Prerequisites
 
-You must be an Azure DevOps Administrator in Azure AD to manage this policy. 
+You must be an Azure DevOps Administrator in Azure AD to manage this policy. However, you do not need to be a Project Collection Admin.
 
 For more information about the new built-in Azure AD roles, see [Administrator role permissions in Azure Active Directory](/azure/active-directory/users-groups-roles/directory-assign-admin-roles).
 


### PR DESCRIPTION
Add detail that you don't need to be a collection admin in Azure DevOps to perform these actions.