### PR TITLE
Make list of agentless tasks visible

### DIFF
--- a/docs/pipelines/process/phases.md
+++ b/docs/pipelines/process/phases.md
@@ -277,18 +277,18 @@ Learn more about [agent capabilities](../agents/agents.md#capabilities).
 
 Tasks in a server job are orchestrated by and executed on the server (Azure Pipelines or TFS). A server job does not require an agent or any target computers. Only a few tasks are supported in a server job at present.
 
-<h3 id="agentless-tasks">Tasks supported in agentless jobs</h3>
+<h3 id="agentless-tasks">Agentless jobs supported tasks</h3>
 
-Currently only the following tasks are supported out of the box for agentless jobs:
+Currently, only the following tasks are supported out of the box for agentless jobs:
 
 * [Delay task](../tasks/utility/delay.md)
-* [Invoke Azure function task](../tasks/utility/azure-function.md)
+* [Invoke Azure Function task](../tasks/utility/azure-function.md)
 * [Invoke REST API task](../tasks/utility/http-rest-api.md)
 * [Publish To Azure Service Bus task](../tasks/utility/publish-to-azure-service-bus.md)
 * [Query Azure Monitor Alerts task](../tasks/utility/azure-monitor.md)
 * [Query Work Items task](../tasks/utility/work-item-query.md)
 
-As tasks are extensible additional agentless tasks can be added through extensions.
+Because tasks are extensible, you can add more agentless tasks by using extensions.
 
 #### [YAML](#tab/yaml/)
 ::: moniker range=">= azure-devops-2019"

--- a/docs/pipelines/process/phases.md
+++ b/docs/pipelines/process/phases.md
@@ -277,6 +277,19 @@ Learn more about [agent capabilities](../agents/agents.md#capabilities).
 
 Tasks in a server job are orchestrated by and executed on the server (Azure Pipelines or TFS). A server job does not require an agent or any target computers. Only a few tasks are supported in a server job at present.
 
+<h3 id="agentless-tasks">Tasks supported in agentless jobs</h3>
+
+Currently only the following tasks are supported out of the box for agentless jobs:
+
+* [Delay task](../tasks/utility/delay.md)
+* [Invoke Azure function task](../tasks/utility/azure-function.md)
+* [Invoke REST API task](../tasks/utility/http-rest-api.md)
+* [Publish To Azure Service Bus task](../tasks/utility/publish-to-azure-service-bus.md)
+* [Query Azure Monitor Alerts task](../tasks/utility/azure-monitor.md)
+* [Query Work Items task](../tasks/utility/work-item-query.md)
+
+As tasks are extensible additional agentless tasks can be added through extensions.
+
 #### [YAML](#tab/yaml/)
 ::: moniker range=">= azure-devops-2019"
 
@@ -315,19 +328,6 @@ You add a server job in the editor by selecting '...' on the **Pipeline** channe
 ::: moniker range="tfs-2017"
 Server jobs are not supported in this version of TFS.
 ::: moniker-end
-
-<h3 id="agentless-tasks">Tasks supported in agentless jobs</h3>
-
-Currently only the following tasks are supported out of the box for agentless jobs:
-
-* [Delay task](../tasks/utility/delay.md)
-* [Invoke Azure function task](../tasks/utility/azure-function.md)
-* [Invoke REST API task](../tasks/utility/http-rest-api.md)
-* [Publish To Azure Service Bus task](../tasks/utility/publish-to-azure-service-bus.md)
-* [Query Azure Monitor Alerts task](../tasks/utility/azure-monitor.md)
-* [Query Work Items task](../tasks/utility/work-item-query.md)
-
-As tasks are extensible additional agentless tasks can be added through extensions.
 
 ---
 


### PR DESCRIPTION
The list of agentless tasks only appears if you select the "Classic" tab. As the list is relevant for YAML as well, it should appear outside of the tabbed area