### PR TITLE
Changed the syntax for the add extension to the correct one, was miss…

### DIFF
--- a/docs/pipelines/apps/cd/azure/build-data-pipeline.md
+++ b/docs/pipelines/apps/cd/azure/build-data-pipeline.md
@@ -77,7 +77,7 @@ To make commands easier to run, start by selecting a default region. After you s
     keyVault="keyvault${resourceSuffix}"
     ```
 
-1. Create one more Bash variable to store the names and the region of your resource group. Replace `<REGION>` with the region that you did choose in the default region section above.
+1. Create one more Bash variable to store the names and the region of your resource group. Replace `<REGION>` with the region that you chose earlier for the default region.
 
     ```bash
     rgName='data-pipeline-cicd-rg'

--- a/docs/pipelines/apps/cd/azure/build-data-pipeline.md
+++ b/docs/pipelines/apps/cd/azure/build-data-pipeline.md
@@ -250,17 +250,17 @@ You will use Azure Key Vault to store all connection information for your Azure 
    ```
 
    ```
-   az pipelines variable-group create --name datapipeline-vg -p <yourazuredevopsprojectname> --variables `
-                                       "LOCATION=$region" `
-                                       "RESOURCE_GROUP=$rgName" `
-                                       "DATA_FACTORY_NAME=$datafactorydev" `
-                                       "DATA_FACTORY_DEV_NAME=$datafactorydev" `
-                                       "DATA_FACTORY_TEST_NAME=$datafactorytest" `
-                                       "ADF_PIPELINE_NAME=DataPipeline" `
-                                       "DATABRICKS_NAME=$databricksname" `
-                                       "AZURE_RM_CONNECTION=azure_rm_connection" `
-                                       "DATABRICKS_URL=<URL copied from Databricks in Azure portal>" `
-                                       "STORAGE_ACCOUNT_NAME=$storageName" `
+   az pipelines variable-group create --name datapipeline-vg -p <yourazuredevopsprojectname> --variables \
+                                       "LOCATION=$region" \
+                                       "RESOURCE_GROUP=$rgName" \
+                                       "DATA_FACTORY_NAME=$datafactorydev" \
+                                       "DATA_FACTORY_DEV_NAME=$datafactorydev" \
+                                       "DATA_FACTORY_TEST_NAME=$datafactorytest" \
+                                       "ADF_PIPELINE_NAME=DataPipeline" \
+                                       "DATABRICKS_NAME=$databricksname" \
+                                       "AZURE_RM_CONNECTION=azure_rm_connection" \
+                                       "DATABRICKS_URL=<URL copied from Databricks in Azure portal>" \
+                                       "STORAGE_ACCOUNT_NAME=$storageName" \
                                        "STORAGE_CONTAINER_NAME=rawdata"
    ```
 

--- a/docs/pipelines/apps/cd/azure/build-data-pipeline.md
+++ b/docs/pipelines/apps/cd/azure/build-data-pipeline.md
@@ -77,10 +77,11 @@ To make commands easier to run, start by selecting a default region. After you s
     keyVault="keyvault${resourceSuffix}"
     ```
 
-1. Create one more Bash variable to store the names of your resource group.
+1. Create one more Bash variable to store the names and the region of your resource group. Replace `<REGION>` with the region that you did choose in the default region section above.
 
     ```bash
     rgName='data-pipeline-cicd-rg'
+    region='<REGION>'
     ```
 
 1. Create variable names for your Azure Data Factory and Azure Databricks instances.

--- a/docs/pipelines/apps/cd/azure/build-data-pipeline.md
+++ b/docs/pipelines/apps/cd/azure/build-data-pipeline.md
@@ -241,7 +241,7 @@ You will use Azure Key Vault to store all connection information for your Azure 
 1. Add the Azure DevOps extension if it isn't already installed. 
 
    ```azurecli
-   az extension add -name azure-devops 
+   az extension add --name azure-devops 
    ```  
 1. Sign in to your [Azure DevOps account](../../../../cli/log-in-via-pat.md).
 


### PR DESCRIPTION
Added a new bash variable to contain the region as this is referenced in the key vault secrets section
Added a hyphen to name parameter in the az add extension code for the azure-devops extension
Changed the line continuation on the key vault secrets to allow the code to be copied more easily 