### PR TITLE
Correction on the format for branch name

### DIFF
--- a/docs/pipelines/process/approvals.md
+++ b/docs/pipelines/process/approvals.md
@@ -63,7 +63,7 @@ To define the branch control check:
 At run time, the check would validate branches for all linked resources in the run against the allowed list. If any one of the branches do not match the criteria, the check fails and the stage is marked failed. 
 
 > [!NOTE]
-> The check requires the branch names to be fully qualified. Make sure the format for branch name is `ref/heads/<branch name>`
+> The check requires the branch names to be fully qualified. Make sure the format for branch name is `refs/heads/<branch name>`
 
 ## Business hours
 


### PR DESCRIPTION
In branch control the fully qualified branch name must be "refs/heads/<branch name>" and not "ref/heads/<branch name>" - an "s" is missing in "ref"