### PR TITLE
Replacing "activates" with "activities"

### DIFF
--- a/docs/test/run-automated-tests-from-test-hub.md
+++ b/docs/test/run-automated-tests-from-test-hub.md
@@ -258,7 +258,7 @@ running tests in scheduled workflow will find it easy to adapt; for
 example, by cloning an existing scheduled testing release pipeline.
 
 Another major benefit is the availability of a rich set of tasks in
-the task catalog that enable a range of activates to be performed before
+the task catalog that enable a range of activities to be performed before
 and after running tests. Examples include preparing and cleaning test data,
 creating and cleaning configuration files, and more.
 


### PR DESCRIPTION
Replacing `range of activates` with `range of activities`.
Fixes #9636