### PR TITLE
Update scheduled-triggers.md

### DIFF
--- a/docs/pipelines/process/scheduled-triggers.md
+++ b/docs/pipelines/process/scheduled-triggers.md
@@ -276,6 +276,9 @@ In the second schedule, **M-F 3:00 AM (UTC - 5) NC daily build**, the cron synta
 > [!IMPORTANT]
 > The UTC time zones in YAML scheduled triggers don't account for daylight savings time.
 
+> [!TIP]
+> When using 3 letter days of the week and wanting a span of multiple days through Sun, Sun should be considered the first day of the week e.g. For a schedule of midnight EST, Thursday to Sunday, the cron syntax is `0 5 * * Sun,Thu-Sat`
+
 ### Example: Nightly build with different frequencies
 
 In this example, the classic editor scheduled trigger has two entries, producing the following builds.


### PR DESCRIPTION
I'm adding this "Tip" to the documentation as one of our devs ran into this issue when using days of the week.  The UI has checkboxes for Mon - Sun and the example above has Mon-Fri.  Following this logic, we used Mon-Sun in the cron task itself, but this then creates a schedule of only two days, Sun and Mon.  This did not seem, per se, to be an actual bug with the code itself, but more of a need to understand how it was generated.
Using `0 5 * * Mon-Sun` generates scheduled runs of midnight EST on Sun and Mon.
Using `0 5 * * Sun-Sat` generates scheduled runs of midnight EST every day

I tried to make the tip a little bit convoluted to show the inclusion of Sunday while skipping certain days.