### PR TITLE
Fix docker load command in caching example

### DIFF
--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -460,7 +460,7 @@ steps:
     displayName: Caching Docker image
 
   - script: |
-      docker load $(Pipeline.Workspace)/docker/cache.tar
+      docker load < $(Pipeline.Workspace)/docker/cache.tar
     condition: and(not(canceled()), eq(variables.DOCKER_CACHE_RESTORED, 'true'))
 
   - script: |


### PR DESCRIPTION
Docker load accepts no arguments, only input