### PR TITLE
Fix bug in mocha example in add-build-task.md

### DIFF
--- a/docs/extend/develop/add-build-task.md
+++ b/docs/extend/develop/add-build-task.md
@@ -374,7 +374,7 @@ it('it should fail if tool returns 1', function(done: Mocha.Done) {
     tr.run();
     console.log(tr.succeeded);
     assert.equal(tr.succeeded, false, 'should have failed');
-    assert.equal(tr.warningIssues, 0, "should have no warnings");
+    assert.equal(tr.warningIssues.length, 0, "should have no warnings");
     assert.equal(tr.errorIssues.length, 1, "should have 1 error issue");
     assert.equal(tr.errorIssues[0], 'Bad input was given', 'error issue output');
     assert.equal(tr.stdout.indexOf('Hello bad'), -1, "Should not display Hello bad");


### PR DESCRIPTION
closes #9700

Following the tutorial, I discovered this example had a bug in it, it makes the test fail where it should pass. Compare with line 338 for reference.