### PR TITLE
Improve step 4 of "Create .. PowerShell module.."

### DIFF
--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -120,8 +120,6 @@ Create a folder named `Get-Hello`. Within that folder create a `Get-Hello.psm1` 
 
 4. The `FunctionsToExport = @()` section is meant to define the module's exported functions. This is simply a list of all exported functions. The following is an example from `PowerShellGet.psd1`:
 
-
-
     ```powershell
     FunctionsToExport = @('Install-Module',
                           'Find-Module',

--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -118,7 +118,9 @@ Create a folder named `Get-Hello`. Within that folder create a `Get-Hello.psm1` 
     RootModule = 'Get-Hello.psm1'
     ```
 
-4. The `FunctionsToExport = @()` section is meant to define the module's exported functions. This is simply a list of all exported functions. Take following is an example from `PowerShellGet.psd1`:
+4. The `FunctionsToExport = @()` section is meant to define the module's exported functions. This is simply a list of all exported functions. The following is an example from `PowerShellGet.psd1`:
+
+
 
     ```powershell
     FunctionsToExport = @('Install-Module',
@@ -147,6 +149,9 @@ Create a folder named `Get-Hello`. Within that folder create a `Get-Hello.psm1` 
                           'Unregister-PSRepository',
                           'Update-ModuleManifest')
     ```
+    
+    > [!TIP]
+    > your module manifest should export the `Get-Hello` function you created in Step 1 
     
 5. It is also possible to define a list of files as part of your module. Just add this list under `FileList=@()`.
 

--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -151,7 +151,7 @@ Create a folder named `Get-Hello`. Within that folder create a `Get-Hello.psm1` 
     ```
     
     > [!TIP]
-    > your module manifest should export the `Get-Hello` function you created in Step 1 
+    > Your module manifest should export the `Get-Hello` function you created in Step 1.
     
 5. It is also possible to define a list of files as part of your module. Just add this list under `FileList=@()`.
 


### PR DESCRIPTION
Improve instructions in step 4 of section "**Create and populate the PowerShell module and module manifest**"
- "Take following" should be "The following"
- Step 4 should also explicitly instruct the reader to export the Get-Hello Function she created in step 1.
