### PR TITLE
Allow *.dev.azure.com instead *dev.azure.com

### DIFF
--- a/docs/organizations/security/allow-list-ip-url.md
+++ b/docs/organizations/security/allow-list-ip-url.md
@@ -25,7 +25,7 @@ Network connection issues could occur because of your security appliances, which
 
 ### Azure DevOps domains to allow
 
-To ensure your organization works with any existing firewall or IP restrictions, ensure that `dev.azure.com` and `*dev.azure.com` are open. 
+To ensure your organization works with any existing firewall or IP restrictions, ensure that `dev.azure.com` and `*.dev.azure.com` are open. 
 
 ### URLs to support sign in and licensing connections
 


### PR DESCRIPTION
This should be subdomain wildcard instead of *dev wildcard. This current implementation would mean hackeddev.azure.com eventually could be made available as urls