### PR TITLE
Getting ref of non-self repo causes exception

### DIFF
--- a/docs/pipelines/repos/multi-repo-checkout.md
+++ b/docs/pipelines/repos/multi-repo-checkout.md
@@ -272,24 +272,6 @@ When you check out multiple repositories, some details about the `self` reposito
 When you use multi-repo triggers, some of those variables have information about the triggering repository instead.
 Details about all of the repositories consumed by the job are available as a [template context object](../process/templates.md#context) called `resources.repositories`.
 
-For example, to get the ref of a non-`self` repository, you could write a pipeline like this:
-
-```yaml
-resources:
-  repositories:
-  - repository: other
-    type: git
-    name: MyProject/OtherTools
-
-variables:
-  tools.ref: $[ resources.repositories['other'].ref ]
-
-steps:
-- checkout: self
-- checkout: other
-- bash: echo "Tools version: $TOOLS_REF"
-```
-
 ## FAQ
 
 * [Why can't I check out a repository from another project? It used to work.](#why-cant-i-check-out-a-repository-from-another-project-it-used-to-work)


### PR DESCRIPTION
When you run following example you will get exception on validating pipeline

> An error occurred while loading the YAML build pipeline. Object reference not set to an instance of an object

I was trying to figure out if this is a bug in documentation or Azure DevOps itself but based [on this](https://developercommunity.visualstudio.com/content/problem/1252381/object-reference-not-set-to-an-instance-of-an-obje-62.html) I had to assume that this is doc issue.

I was trying to find out what is in `resources.repositories` but I couldn't make it. Probably whole `Repository details` should be updated or deleted as it doesn't provide any value at the moment.