### PR TITLE
Document 'force32bit' argument for NodeToolv0

### DIFF
--- a/docs/pipelines/tasks/includes/yaml/NodeToolV0.md
+++ b/docs/pipelines/tasks/includes/yaml/NodeToolV0.md
@@ -13,5 +13,6 @@ ms.technology: devops-cicd-tasks
 - task: NodeTool@0
   inputs:
     #versionSpec: '6.x' 
+    #force32bit: false # Optional
     #checkLatest: false # Optional
 ```

--- a/docs/pipelines/tasks/tool/node-js.md
+++ b/docs/pipelines/tasks/tool/node-js.md
@@ -35,6 +35,7 @@ None
 | Argument | Description |
 |----------|-------------|
 |`versionSpec`<br/> Version Spec | (Required) Specify which [Node.js version](https://nodejs.org/en/download/releases/) you want to use, using semver's version range syntax. <br/>**Examples**: `7.x`, `6.x`, `6.10.0`, `>=6.10.0` <br/>Default value: `6.x`|
+|`force32bit`<br/> Use 32 bit version on x64 agents | (Optional) Install the x86 version of Node.js on a 64-bit Windows agent. Only works on Windows.|
 |`checkLatest`<br/> Check for Latest Version | (Optional) Select if you want the agent to check for the latest available version that satisfies the version spec. For example, you select this option because you run this build on your [self-hosted agent](../../agents/agents.md#install) and you want to always use the latest `6.x` version.|
 
 > [!TIP]


### PR DESCRIPTION
Hi folks, wanted to document this cool new feature that's been added to the NodeTool and UseNode tasks: https://github.com/microsoft/azure-pipelines-tasks/pull/13399

(Note: The feature is definitely live, as the Atom text editor has started using it in their CI: https://github.com/atom/atom/pull/21490. I wanted to make sure others knew about this neat feature that makes building 32-bit Node apps easy even on 64-bit Windows agents.)

Note: I formatted the documentation such that `force32bit` is above `checkLatest`, because `node-js.md` has a `[!TIP]` box below the table that is referring specifically to `checkLatest`. Otherwise I would have added it to the bottom of the table.

If there are any wording/formatting changes needed, or anything at all, feel free to let me know. Thanks.