### PR TITLE
Updating troubleshooting section

### DIFF
--- a/docs/pipelines/tasks/deploy/azure-resource-group-deployment.md
+++ b/docs/pipelines/tasks/deploy/azure-resource-group-deployment.md
@@ -99,5 +99,3 @@ In addition, refer to this article regarding structure and syntax of ARM Templat
 
 
 ## Open source
-
-This task is open source [on GitHub](https://github.com/Microsoft/azure-pipelines-tasks). Feedback and contributions are welcome.

--- a/docs/pipelines/tasks/deploy/azure-resource-group-deployment.md
+++ b/docs/pipelines/tasks/deploy/azure-resource-group-deployment.md
@@ -100,5 +100,4 @@ In addition, refer to this article regarding structure and syntax of ARM Templat
 
 ## Open source
 
-
 This task is open source [on GitHub](https://github.com/Microsoft/azure-pipelines-tasks). Feedback and contributions are welcome.

--- a/docs/pipelines/tasks/deploy/azure-resource-group-deployment.md
+++ b/docs/pipelines/tasks/deploy/azure-resource-group-deployment.md
@@ -71,6 +71,14 @@ Timeout issues could be coming from two places:
 
 You can identify if the timeout is from portal, by checking for the portal deployment link that'll be in the task logs. If there's no link, this is likely due to Azure Pipelines agent. If there's a link, follow the link to see if there's a timeout that has happened in the portal deployment.
 
+### Error: CORS rules to be enabled while overriding parameters
+
+If the template file if being referred from a BLOB, while overriding parameters in the pipeline, you can get the following :
+
+Warning: Failed to download the file from template path. This feature requires that CORS rules are enabled at the source. If templates are in Azure storage blob, refer to [this](https://docs.microsoft.com/en-us/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services?redirectedfrom=MSDN#understanding-cors-requests) to enable CORS. 
+
+Besides enabling CORS, ensure that the SAS token specified in the link of the template is "srt-sco", only then it allowes you to download the file and proceed.
+
 #### Azure Pipelines Agent
 
 If the issue is coming from Azure Pipelines agent, you can increase the timeout by setting timeoutInMinutes as key in the YAML to 0. Check out this article for more details: https://docs.microsoft.com/azure/devops/pipelines/process/phases?tabs=yaml.

--- a/docs/pipelines/tasks/deploy/azure-resource-group-deployment.md
+++ b/docs/pipelines/tasks/deploy/azure-resource-group-deployment.md
@@ -73,11 +73,13 @@ You can identify if the timeout is from portal, by checking for the portal deplo
 
 ### Error: CORS rules to be enabled while overriding parameters
 
-If the template file if being referred from a BLOB, while overriding parameters in the pipeline, you can get the following :
+If the template file is being referred from a BLOB, while overriding parameters in the pipeline, you might see the following warning message:
 
-Warning: Failed to download the file from template path. This feature requires that CORS rules are enabled at the source. If templates are in Azure storage blob, refer to [this](https://docs.microsoft.com/en-us/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services?redirectedfrom=MSDN#understanding-cors-requests) to enable CORS. 
+`Warning: Failed to download the file from template path.`
 
-Besides enabling CORS, ensure that the SAS token specified in the link of the template is "srt-sco", only then it allowes you to download the file and proceed.
+This feature requires the CORS rules to be enabled at the source. If templates are in Azure storage blob, see [Cross-origin resource sharing support](/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services?redirectedfrom=MSDN#understanding-cors-requests) to enable CORS. 
+
+Besides enabling CORS, ensure that the SAS token specified in the link of the template is "srt-sco". This token is required for you to download the file and proceed.
 
 #### Azure Pipelines Agent
 

--- a/docs/pipelines/tasks/deploy/azure-resource-group-deployment.md
+++ b/docs/pipelines/tasks/deploy/azure-resource-group-deployment.md
@@ -99,3 +99,6 @@ In addition, refer to this article regarding structure and syntax of ARM Templat
 
 
 ## Open source
+
+
+This task is open source [on GitHub](https://github.com/Microsoft/azure-pipelines-tasks). Feedback and contributions are welcome.


### PR DESCRIPTION
While using templates from a BLOB, the template URL should have proper parameter, otherwise it deosn't let you download the template and proceed.