### PR TITLE
Update sprint-143-update.md

### DIFF
--- a/release-notes/2018/sprint-143-update.md
+++ b/release-notes/2018/sprint-143-update.md
@@ -133,7 +133,7 @@ Previously, we required you to declare your container resources in YAML pipeline
 jobs:
 - job: my-container-job
   container:
-    image: microsoft/dotnet:latest
+    image: mcr.microsoft.com/dotnet/core/runtime:latest
 ```
 
 ### Changes to default permissions for new projects


### PR DESCRIPTION
Updated to refer to equivalent microsoft image from Microsoft Container Registry instead of from Docker Hub. 

I realize the Microsoft container image reference in this article is an example, but MCR is required for any official Microsoft image. Please reach out to danlep if you need more context for this change. Thanks :)