### PR TITLE
Add link to YAML usage in manual-intervention.md

### DIFF
--- a/docs/pipelines/tasks/utility/manual-intervention.md
+++ b/docs/pipelines/tasks/utility/manual-intervention.md
@@ -19,7 +19,7 @@ typically to perform some manual steps or actions, and then continue the automat
 
 ## Demands
 
-Can be used in only an [agentless job](../../process/phases.md#server-jobs) of a release pipeline. This guide refers to classic pipelines only. For YAML usage, please refer to the [Manual Validation Task page](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/manual-validation?view=azure-devops&tabs=yaml).
+Can be used in only an [agentless job](../../process/phases.md#server-jobs) of a release pipeline. This article refers only to classic pipelines. For YAML usage, see [Manual Validation task](manual-validation.md?view=azure-devops&tabs=yaml).
 
 ![Configuring a Manual Intervention task](media/maninter-use-variables.png)
 

--- a/docs/pipelines/tasks/utility/manual-intervention.md
+++ b/docs/pipelines/tasks/utility/manual-intervention.md
@@ -19,7 +19,7 @@ typically to perform some manual steps or actions, and then continue the automat
 
 ## Demands
 
-Can be used in only an [agentless job](../../process/phases.md#server-jobs) of a release pipeline. This task is supported only in classic release pipelines.
+Can be used in only an [agentless job](../../process/phases.md#server-jobs) of a release pipeline. This guide refers to classic pipelines only. For YAML usage, please refer to the [Manual Validation Task page](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/manual-validation?view=azure-devops&tabs=yaml).
 
 ![Configuring a Manual Intervention task](media/maninter-use-variables.png)
 

--- a/docs/pipelines/tasks/utility/manual-intervention.md
+++ b/docs/pipelines/tasks/utility/manual-intervention.md
@@ -19,7 +19,7 @@ typically to perform some manual steps or actions, and then continue the automat
 
 ## Demands
 
-Can be used in only an [agentless job](../../process/phases.md#server-jobs) of a release pipeline. This article refers only to classic pipelines. For YAML usage, see [Manual Validation task](manual-validation.md?view=azure-devops&tabs=yaml).
+Can be used in only an [agentless job](../../process/phases.md#server-jobs) of a release pipeline. This article refers only to classic pipelines. For YAML usage, see [Manual Validation task](manual-validation.md).
 
 ![Configuring a Manual Intervention task](media/maninter-use-variables.png)
 


### PR DESCRIPTION
I notice that the very same feature described here is available for YAML syntax using Manual Validation task. As such task seems to be recently introduced (11/30/2020), I guess this page has just not been updated yet. Hence the PR.