### PR TITLE
Update timeoutInMinutes as Optional

### DIFF
--- a/docs/pipelines/tasks/utility/manual-validation.md
+++ b/docs/pipelines/tasks/utility/manual-validation.md
@@ -40,7 +40,7 @@ send email notifications to users and user groups when it is awaiting a review,
 and specify the automatic response (reject or resume) after a configurable
 timeout occurs.
 
-You can specify the timeout value for the task using the `timeoutInMinutes` parameter available in control options. 
+You can specify the timeout value for the task using the `timeoutInMinutes` parameter available in control options. This parameter is optional. 
 
 > [!NOTE]
 > For the task to run completely, the timeout value of the job should be higher than the timeout value of the task. See [default job timeout values](../../process/phases.md#timeouts). 


### PR DESCRIPTION
Noticed documentation didn't call out if the timeoutInMinutes parameter was required or not.  Tried it out and it is not required.