### PR TITLE
Added single quotes to avoid getting exception

### DIFF
--- a/docs/pipelines/process/run-number.md
+++ b/docs/pipelines/process/run-number.md
@@ -26,7 +26,7 @@ You can use a combination of tokens, variables, and underscore characters.
 name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
 steps:
-  - script: echo $(Build.BuildNumber) # outputs customized build number like project_def_master_20200828.1
+  - script: echo '$(Build.BuildNumber)' # outputs customized build number like project_def_master_20200828.1
 ```
 
 ::: moniker-end


### PR DESCRIPTION
Without single quote I was getting exception:

```
2021-01-04T21:55:39.2262233Z ##[section]Starting: CmdLine
2021-01-04T21:55:39.2268224Z ==============================================================================
2021-01-04T21:55:39.2268761Z Task         : Command line
2021-01-04T21:55:39.2269124Z Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
2021-01-04T21:55:39.2269499Z Version      : 2.178.0
2021-01-04T21:55:39.2270047Z Author       : Microsoft Corporation
2021-01-04T21:55:39.2270461Z Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line
2021-01-04T21:55:39.2270867Z ==============================================================================
2021-01-04T21:55:39.7179888Z Generating script.
2021-01-04T21:55:39.7189196Z Script contents:
2021-01-04T21:55:39.7190241Z echo DevOps Manual_kmadof.devops-manual (69)_master_20210104.1
2021-01-04T21:55:39.7191072Z ========================== Starting Command Output ===========================
2021-01-04T21:55:39.7215588Z [command]/bin/bash --noprofile --norc /home/vsts/work/_temp/7788d3a6-b0c9-483c-9104-5832889c18c0.sh
2021-01-04T21:55:39.7263332Z /home/vsts/work/_temp/7788d3a6-b0c9-483c-9104-5832889c18c0.sh: line 1: syntax error near unexpected token `('
2021-01-04T21:55:39.7264482Z /home/vsts/work/_temp/7788d3a6-b0c9-483c-9104-5832889c18c0.sh: line 1: `echo DevOps Manual_kmadof.devops-manual (69)_master_20210104.1'
2021-01-04T21:55:39.7313006Z ##[error]Bash exited with code '2'.
2021-01-04T21:55:39.7396190Z ##[section]Finishing: CmdLine
```