### PR TITLE
Fix for missing 'Section' formatting command

### DIFF
--- a/docs/pipelines/scripts/logging-commands.md
+++ b/docs/pipelines/scripts/logging-commands.md
@@ -58,6 +58,7 @@ The formatting commands are:
 ##[group]Beginning of a group
 ##[warning]Warning message
 ##[error]Error message
+##[section]Start of a section
 ##[debug]Debug text
 ##[command]Command-line being run
 ##[endgroup]


### PR DESCRIPTION
This is the fix for issue #9943 