### PR TITLE
Fix: Pipeline publish path incorrect

### DIFF
--- a/docs/pipelines/ecosystems/includes/deployment-variables.md
+++ b/docs/pipelines/ecosystems/includes/deployment-variables.md
@@ -16,6 +16,8 @@ variables:
   # the name of your web app here is the same one you used above
   # when you created the web app using the Azure CLI
   appName: my-app-name
-  
+  # the name of your functionApp is what you provided as
+  # stagingDirectory in pom.xml
+  functionAppName: 'javafunctions'
 # ...
 ```

--- a/docs/pipelines/ecosystems/java-function.md
+++ b/docs/pipelines/ecosystems/java-function.md
@@ -77,7 +77,7 @@ After the pipeline has run, select the vertical ellipses in the upper-right corn
 - task: CopyFiles@2
   displayName: Copy Files
   inputs:
-    SourceFolder: $(system.defaultworkingdirectory)/target/azure-functions/
+    SourceFolder: $(system.defaultworkingdirectory)/target/azure-functions/$(functionAppName)/
     Contents: '**'
     TargetFolder: $(build.artifactstagingdirectory)   
 


### PR DESCRIPTION
This would resolve #9959.

I have added a variable for functiomAppName and used it while copyTask to get correct build artifacts