### PR TITLE
Updated required inputs

### DIFF
--- a/docs/pipelines/tasks/deploy/azure-app-service-settings.md
+++ b/docs/pipelines/tasks/deploy/azure-app-service-settings.md
@@ -23,7 +23,7 @@ The task works for ASP.NET, ASP.NET Core, PHP, Java, Python, Go and Node.js base
 |--- |--- |
 |`ConnectedServiceName`<br/>Azure subscription|(Required) Name of the Azure Resource Manager service connection <br/>Argument aliases: `ConnectedServiceName`|
 |`appName`<br/>App name|(Required) Name of an existing App Service|
-|`resourceGroupName`<br/>Resource group|(Required) Name of the resource group|
+|`resourceGroupName`<br/>Resource group|(Optional) Name of the resource group|
 |`slotName`<br/>Slot|(Optional) Name of the slot<br/>Default value: `production`|
 |`appSettings`<br/>App settings|(Optional) Application settings to be entered using JSON syntax. Values containing spaces should be enclosed in double quotes.|
 |`generalSettings`<br/>General settings|(Optional) General settings to be entered using JSON syntax. Values containing spaces should be enclosed in double quotes. See the [App Service SiteConfig object documentation](/azure/templates/microsoft.web/sites#siteconfig-object) for the available properties.|


### PR DESCRIPTION
ResourceGroupName is listed as a required input however, it is not required.  As well as the example provided does not include it.

This would resolve #9969 