### PR TITLE
Docker-compose: Fix ports configuration

### DIFF
--- a/docs/pipelines/tasks/build/docker-compose.md
+++ b/docs/pipelines/tasks/build/docker-compose.md
@@ -187,7 +187,7 @@ This YAML example runs a specific service:
     projectName: $(Build.Repository.Name)
     qualifyImageNames: true
     serviceName: myhealth.web
-    ports: 80
+    ports: 80:80
     detached: true
 ```
 


### PR DESCRIPTION
This is explained just above the modified text:

> `ports` (Ports): (Optional) Ports in the specific service container to publish to the host. Specify each host-port:container-port binding on a new line.