### PR TITLE
Updating sprint / iteration limit

### DIFF
--- a/docs/organizations/settings/work/object-limits.md
+++ b/docs/organizations/settings/work/object-limits.md
@@ -9,7 +9,7 @@ ms.author: kaelli
 author: KathrynEE
 ms.topic: reference
 monikerRange: ">= tfs-2013"
-ms.date: 07/24/2020
+ms.date: 01/19/2021
 ---
 
 # Work tracking, process, and project limits
@@ -72,6 +72,8 @@ When working with teams, work item tags, backlogs, and boards, the following ope
 | Taskboard | 1000 tasks  | 
 | Teams | 5,000 per project | 
 | Work item tags | 150,000 tag definitions per project | 
+| Iterations | 300 per project
+| Area Paths | 300 per project
 
 Each backlog can display up to 10,000 work items. This is simply a limit on what the backlog can display, not a limit on the number of work items you can define. If your backlog exceeds this limit, then you may want to consider adding a team and moving some of the work items to the other team's backlog.
 


### PR DESCRIPTION
It looks like we have an undocumented limit for sprints / iterations at 300 each per project. Adding this to the docs.