### PR TITLE
Updating undocumented area path / iteration limits

### DIFF
--- a/docs/organizations/settings/work/object-limits.md
+++ b/docs/organizations/settings/work/object-limits.md
@@ -72,8 +72,8 @@ When working with teams, work item tags, backlogs, and boards, the following ope
 | Taskboard | 1,000 tasks  | 
 | Teams | 5,000 per project | 
 | Work item tags | 150,000 tag definitions per organization or collection | 
-| Area paths | 300 per project
-| Iterations | 300 per project
+| Area Paths | 300 per project
+| Iteration Paths | 300 per project
 
 Each backlog can display up to 10,000 work items. This is a limit on what the backlog can display, not a limit on the number of work items you can define. If your backlog exceeds this limit, then you may want to consider adding a team and moving some of the work items to the other team's backlog.
 

--- a/docs/organizations/settings/work/object-limits.md
+++ b/docs/organizations/settings/work/object-limits.md
@@ -9,7 +9,7 @@ ms.author: kaelli
 author: KathrynEE
 ms.topic: reference
 monikerRange: ">= tfs-2013"
-ms.date: 11/06/2020
+ms.date: 01/19/2021
 ---
 
 # Work tracking, process, and project limits
@@ -72,6 +72,8 @@ When working with teams, work item tags, backlogs, and boards, the following ope
 | Taskboard | 1,000 tasks  | 
 | Teams | 5,000 per project | 
 | Work item tags | 150,000 tag definitions per organization or collection | 
+| Area paths | 300 per project
+| Iterations | 300 per project
 
 Each backlog can display up to 10,000 work items. This is a limit on what the backlog can display, not a limit on the number of work items you can define. If your backlog exceeds this limit, then you may want to consider adding a team and moving some of the work items to the other team's backlog.
 


### PR DESCRIPTION
Looks like we have an undocumented hard limit of 300 area paths and 300 iterations per project. Updating this limits doc to reflect that