### PR TITLE
Fixes incorrect link title in "Analyze and report on code churn and code coverage"

### DIFF
--- a/docs/report/sql-reports/perspective-code-analyze-report-code-churn-coverage.md
+++ b/docs/report/sql-reports/perspective-code-analyze-report-code-churn-coverage.md
@@ -151,7 +151,7 @@ The following table describes the measures in the Run Coverage measure group. By
   
 ## Related notes
 -  [Code Churn](/previous-versions/azure/devops/report/excel/code-churn-excel-report)   
--  [Code Churn](/previous-versions/azure/devops/report/excel/code-coverage-excel-report)  
+-  [Code Coverage](/previous-versions/azure/devops/report/excel/code-coverage-excel-report)  
 -  [Code Churn tables](table-reference-code-churn.md)   
 -  [Run Coverage tables](run-coverage-tables.md)   
 -  [Perspectives and measure groups in the Analysis Services cube](perspective-measure-groups-cube.md)


### PR DESCRIPTION
In the "Related notes" section, a link titled "Code Churn" appears two times.

The first link seems correct, as it links to [Code Churn Excel Report
](https://docs.microsoft.com/en-us/previous-versions/azure/devops/report/excel/code-churn-excel-report).
The second link, however, links to [Code Coverage Excel Report](https://docs.microsoft.com/en-us/previous-versions/azure/devops/report/excel/code-coverage-excel-report).

Logic would dictate that the link title, therefore, should not be "Code Churn" but "Code Coverage".

This MR fixes that.