### PR TITLE
Fix ACR input param format when pushing module image

### DIFF
--- a/docs/pipelines/tasks/build/azure-iot-edge.md
+++ b/docs/pipelines/tasks/build/azure-iot-edge.md
@@ -73,7 +73,7 @@ steps:
     action: Push module images
     containerregistrytype: Azure Container Registry
     azureSubscriptionEndpoint: $(azureSubscriptionEndpoint)
-    azureContainerRegistry: $(azureContainerRegistry)
+    azureContainerRegistry: {"loginServer":"$(azureContainerRegistry)", "id":"$(azureSubscriptionEndpoint)"}
     templateFilePath: deployment.template.json
     defaultPlatform: amd64  
 ```


### PR DESCRIPTION
The YAML documentation for pushing the module image had the incorrect format for passing in the Azure Container Registry. Hence, this needs to be fixed