### PR TITLE
Update packages search toc name

### DIFF
--- a/docs/project/search/toc.yml
+++ b/docs/project/search/toc.yml
@@ -6,7 +6,7 @@
   href: work-item-search.md
 - name: Search wiki
   href: ../wiki/search-wiki.md
-- name: Search work items
+- name: Search packages or artifacts
   href: package-search.md
 - name: Advanced code search
   href: advanced-code-search-syntax.md


### PR DESCRIPTION
In the Page navigation it currently says "Search work items" for the packages and artifacts search page. Fixing this likely copy and paste issue