### PR TITLE
Update teams.md

### DIFF
--- a/docs/service-hooks/services/teams.md
+++ b/docs/service-hooks/services/teams.md
@@ -22,7 +22,7 @@ See activity about your Azure DevOps Server (2017.2 and later) projects directly
 
 ::: moniker range=">= azure-devops-2020"
 > [!NOTE]
-> For Azure DevOps Services and Azure DevOps 2020 and later versions, we recommend you use the following suite of apps which offer rich features, to integrate with Microsoft Teams.
+> For Azure DevOps Services, we recommend you use the following suite of apps which offer rich features, to integrate with Microsoft Teams.
 
 ### Azure Boards app for Teams
 

--- a/docs/service-hooks/services/teams.md
+++ b/docs/service-hooks/services/teams.md
@@ -20,7 +20,7 @@ See activity about your Azure DevOps Server (2017.2 and later) projects directly
 * Release deployments and approvals
 
 
-::: moniker range=">= azure-devops-2020"
+::: moniker range="azure-devops"
 > [!NOTE]
 > For Azure DevOps Services, we recommend you use the following suite of apps which offer rich features, to integrate with Microsoft Teams.
 
@@ -38,7 +38,7 @@ See activity about your Azure DevOps Server (2017.2 and later) projects directly
 
 ::: moniker-end
 
-::: moniker range=">= tfs-2017 <= azure-devops-2019"
+::: moniker range=">= tfs-2017 <= azure-devops-2020"
 
 ## Configure a new connector for Azure DevOps Server
 


### PR DESCRIPTION
In the Note, removed the recommendation for "Azure DevOps Server 2020 and latest versions" because this feature is not yet supported with Azure DevOps Server 2020 as noted in this link below:

https://docs.microsoft.com/en-us/azure/devops/boards/integrations/boards-teams?view=azure-devops
You can link the Azure Boards app for Microsoft Teams only to a project hosted on Azure DevOps Services at this time.