### PR TITLE
Indentation on yaml snippet incorrect

### DIFF
--- a/docs/pipelines/ecosystems/python-webapp.md
+++ b/docs/pipelines/ecosystems/python-webapp.md
@@ -222,7 +222,7 @@ Then we have script-based task that creates a virtual environment and installs d
            pip install -r requirements.txt
          workingDirectory: $(projectRoot)
          displayName: "Install requirements"
-      ```
+   ```
 
 
 - Next step creates the *.zip* file that the steps under deploy stage of the pipeline deploys. To create the *.zip* file, add an [ArchiveFiles](../tasks/utility/archive-files.md) task to the end of the YAML file:


### PR DESCRIPTION
It's a tab space out so leaves the ``` code markup on the line below the yaml snippet, could be confusing to anyone new to pipelines/markdown and copying the code