### PR TITLE
Update practices that scale - SoS link broken

### DIFF
--- a/docs/boards/plans/practices-that-scale.md
+++ b/docs/boards/plans/practices-that-scale.md
@@ -68,7 +68,7 @@ Some specific Agile practices that scale well and lead to happier, engaged, and 
 
 - **Embedded leadership**: Empower teams and leaders within the organization to self-organize and self-manage as much as possible. Team autonomy increases organizational agility team effectiveness. Ensure teams have the corporate sponsorship needed to succeed.  
 - **Daily stand-ups**: Or, [Scrum meetings](../sprints/best-practices-scrum.md#daily-scrum-meetings) help keeps teams focused on what they need to do daily to maximize their ability to meet their sprint commitments. As organizations grow, they should consider staggering these meetings so that cross-team participation can occur as needed.  
-- **[Scrum of scrums](http://guide.agilealliance.org/guide/scrumofscrums.html)**: Daily standups of members from different Agile teams meet daily to report work completed, next steps, and issues or blocks occurring within their representative teams. 
+- **[Scrum of scrums](https://www.agilealliance.org/glossary/scrum-of-scrums)**: Daily standups of members from different Agile teams meet daily to report work completed, next steps, and issues or blocks occurring within their representative teams. 
 - **Team communications**: Provide and encourage teams to share their practices and guidance, which they and other teams can access through the corporate network. Common tools used for this purpose include team wikis, OneNotes, or markdown sites.  
 - **Collaboration**: Encourage informal team-to-team communications as well as collaboration within the team. Institutionalizing practices such as code reviews, design reviews, spec reviews not only increase team collaboration but help develop individual as well as overall corporate competence.  
 


### PR DESCRIPTION
Scrum of scrum link went to dead page, updated with current SoS definition page from the same source, Agile Alliance.

There does not appear to be an SoS guide hosted by this organization any more.  I found a brief one at the Agilest:
https://www.agilest.org/scaled-agile/scrum-of-scrums/

