### PR TITLE
Fix test for working directory

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -95,7 +95,7 @@ Next, create the Dockerfile.
     
     Remove-Item Env:AZP_TOKEN
     
-    if ($Env:AZP_WORK -and -not (Test-Path Env:AZP_WORK)) {
+    if ((Test-Path Env:AZP_WORK) -and -not (Test-Path $Env:AZP_WORK)) {
       New-Item $Env:AZP_WORK -ItemType directory | Out-Null
     }
     


### PR DESCRIPTION
Use Test-Path to check the environment variable (as elsewhere) to be compatible with strict mode
Then pass the actual value of the environment variable to Test-Path to decide if we need to New-Item the directory