### PR TITLE
Updated doc for AzurePowerShell task to latest version

### DIFF
--- a/docs/pipelines/tasks/deploy/azure-powershell.md
+++ b/docs/pipelines/tasks/deploy/azure-powershell.md
@@ -20,7 +20,7 @@ Use this task to run a PowerShell script within an Azure environment. The Azure 
 
 ## YAML snippet
 
-[!INCLUDE [temp](../includes/yaml/AzurePowerShellV4.md)]
+[!INCLUDE [temp](../includes/yaml/AzurePowerShellV5.md)]
 
 ::: moniker-end
 
@@ -37,10 +37,12 @@ Use this task to run a PowerShell script within an Azure environment. The Azure 
 |`FailOnStandardError`<br/>Fail on Standard Error|(Optional) If this is true, this task will fail if any errors are written to the error pipeline, or if any data is written to the Standard Error stream. <br/>Default value: `false`|
 |`TargetAzurePs`<br/>Azure PowerShell Version|(Required) In case of Microsoft-hosted agents, the supported Azure PowerShell version. To pick the latest version available on the agent, select `Latest installed version.` <br/>For self-hosted agents, you can specify preferred version of Azure PowerShell using "Specify version" <br/>Default value: `OtherVersion` <br/>Argument alias: `azurePowerShellVersion`|
 |`CustomTargetAzurePs`<br/>preferredAzurePowerShellVersion|(Required when TargetAzurePs = OtherVersion) <br/>Preferred Azure PowerShell Version needs to be a proper semantic version. For example, 1.2.3. Regex like 2.\*,2.3.\* is not supported. <br/>Argument alias: `preferredAzurePowerShellVersion`|
+|`pwsh`<br />Use PowerShell Core|(Optional) If this is true, then on Windows the task will use pwsh.exe from your PATH instead of powershell.exe.|
+|`workingDirectory`<br />Working Directory|(Optional) Working directory where the script is run.|
 
 ## Samples
 
-[!INCLUDE [temp](../includes/yaml/AzurePowerShellV4Sample.md)]
+[!INCLUDE [temp](../includes/yaml/AzurePowerShellV5Sample.md)]
 
 ## Troubleshooting
 ### Script worked locally, but failed in the pipeline

--- a/docs/pipelines/tasks/deploy/azure-powershell.md
+++ b/docs/pipelines/tasks/deploy/azure-powershell.md
@@ -54,14 +54,7 @@ To resolve this issue, ensure the service principle/ authentication credentials 
 
 ### Error: Could not find the modules: '<module name>' with Version: '<version>'. If the module was recently installed, retry after restarting the Azure Pipelines task agent
 
-Azure PowerShell task uses Azure/AzureRM/Az PowerShell Module to interact with Azure Subscription. This issue occurs when the PowerShell module is not available on the Hosted Agent. Hence, for a particular task version, *Preferred Azure PowerShell version* must be specified in the **Azure PowerShell version options** from the following available list of versions. 
-
-<table><thead><tr><th>Task Version</th><th>Available versions of PowerShell Modules</th></tr></thead>
-<tr><td>2.* </td><td>Choose one from any of the 2 lists:<br>Azure: 2.1.0, 3.8.0, 4.2.1, 5.1.1<br>AzureRM: 2.1.0, 3.8.0, 4.2.1, 5.1.1, 6.7.0</td></tr>
-<tr><td>3.* </td><td>Choose one from any of the 2 lists:<br>Azure: 2.1.0, 3.8.0, 4.2.1, 5.1.1<br>AzureRM: 2.1.0, 3.8.0, 4.2.1, 5.1.1, 6.7.0</td></tr>
-<tr><td>4.*</td><td>Az Module: 1.0.0, 1.6.0, 2.3.2, 2.6.0, 3.1.0, 3.5.0</td></tr>
-<tr><td>5.*</td><td>Az Module: 1.0.0, 1.6.0, 2.3.2, 2.6.0, 3.1.0</td></tr>
-</table>
+Azure PowerShell task uses Azure/AzureRM/Az PowerShell Module to interact with Azure Subscription. This issue occurs when the PowerShell module is not available on the Hosted Agent. Hence, for a particular task version, *Preferred Azure PowerShell version* must be specified in the **Azure PowerShell version options** from the list of available versions. The installed software can be found on the [Software](..\..\agents\hosted.md#software) table on the [Microsoft-hosted agents](..\..\agents\hosted.md) page.
 
 ### Service Connection Issues
 To troubleshoot issues related to service connections, see [Service Connection troubleshooting](../../release/azure-rm-endpoint.md)

--- a/docs/pipelines/tasks/deploy/azure-powershell.md
+++ b/docs/pipelines/tasks/deploy/azure-powershell.md
@@ -37,7 +37,7 @@ Use this task to run a PowerShell script within an Azure environment. The Azure 
 |`FailOnStandardError`<br/>Fail on Standard Error|(Optional) If this is true, this task will fail if any errors are written to the error pipeline, or if any data is written to the Standard Error stream. <br/>Default value: `false`|
 |`TargetAzurePs`<br/>Azure PowerShell Version|(Required) In case of Microsoft-hosted agents, the supported Azure PowerShell version. To pick the latest version available on the agent, select `Latest installed version.` <br/>For self-hosted agents, you can specify preferred version of Azure PowerShell using "Specify version" <br/>Default value: `OtherVersion` <br/>Argument alias: `azurePowerShellVersion`|
 |`CustomTargetAzurePs`<br/>preferredAzurePowerShellVersion|(Required when TargetAzurePs = OtherVersion) <br/>Preferred Azure PowerShell Version needs to be a proper semantic version. For example, 1.2.3. Regex like 2.\*,2.3.\* is not supported. <br/>Argument alias: `preferredAzurePowerShellVersion`|
-|`pwsh`<br />Use PowerShell Core|(Optional) If this is true, then on Windows the task will use pwsh.exe from your PATH instead of powershell.exe.|
+|`pwsh`<br />Use PowerShell Core|(Optional) If this is true, on Windows, the task will use pwsh.exe from your PATH instead of powershell.exe.|
 |`workingDirectory`<br />Working Directory|(Optional) Working directory where the script is run.|
 
 ## Samples
@@ -52,12 +52,12 @@ This typically occurs when the service connection used in the pipeline has insuf
 To resolve this issue, ensure the service principle/ authentication credentials have the required permissions. For more information, see 
    [Use Role-Based Access Control to manage access to your Azure subscription resources](/azure/role-based-access-control/role-assignments-portal).
 
-### Error: Could not find the modules: '<module name>' with Version: '<version>'. If the module was recently installed, retry after restarting the Azure Pipelines task agent
+### Error: Could not find the modules: '\<module name\>' with Version: '\<version\>'. If the module was recently installed, retry after restarting the Azure Pipelines task agent
 
-Azure PowerShell task uses Azure/AzureRM/Az PowerShell Module to interact with Azure Subscription. This issue occurs when the PowerShell module is not available on the Hosted Agent. Hence, for a particular task version, *Preferred Azure PowerShell version* must be specified in the **Azure PowerShell version options** from the list of available versions. The installed software can be found on the [Software](..\..\agents\hosted.md#software) table on the [Microsoft-hosted agents](..\..\agents\hosted.md) page.
+Azure PowerShell task uses Azure/AzureRM/Az PowerShell Module to interact with Azure Subscription. This issue occurs when the PowerShell module is not available on the Hosted Agent. Hence, for a particular task version, *Preferred Azure PowerShell version* must be specified in the **Azure PowerShell version options** from the list of available versions. The installed software can be found in the [Software](../../agents/hosted.md#software) table in [Microsoft-hosted agents](../../agents/hosted.md).
 
 ### Service Connection Issues
-To troubleshoot issues related to service connections, see [Service Connection troubleshooting](../../release/azure-rm-endpoint.md)
+To troubleshoot issues related to service connections, see [Service Connection troubleshooting](../../release/azure-rm-endpoint.md).
 
 ## Open source
 

--- a/docs/pipelines/tasks/includes/yaml/AzurePowerShellV5.md
+++ b/docs/pipelines/tasks/includes/yaml/AzurePowerShellV5.md
@@ -10,7 +10,7 @@ ms.technology: devops-cicd-tasks
 ```YAML
 # Azure PowerShell
 # Run a PowerShell script within an Azure environment
-- task: AzurePowerShell@4
+- task: AzurePowerShell@5
   inputs:
     #azureSubscription: Required. Name of Azure Resource Manager service connection
     #scriptType: 'FilePath' # Optional. Options: filePath, inlineScript
@@ -21,4 +21,5 @@ ms.technology: devops-cicd-tasks
     #failOnStandardError: false # Optional
     #azurePowerShellVersion: 'OtherVersion' # Required. Options: latestVersion, otherVersion
     #preferredAzurePowerShellVersion: # Required when azurePowerShellVersion == OtherVersion
+    #pwsh: true # Optional. If true, then will use PowerShell Core pwsh.exe
 ```

--- a/docs/pipelines/tasks/includes/yaml/AzurePowerShellV5Sample.md
+++ b/docs/pipelines/tasks/includes/yaml/AzurePowerShellV5Sample.md
@@ -8,7 +8,7 @@ ms.technology: devops-cicd-tasks
 ---
 
 ```YAML
-- task: AzurePowerShell@4
+- task: AzurePowerShell@5
   inputs:
     azureSubscription: my-arm-service-connection
     scriptType: filePath
@@ -18,4 +18,5 @@ ms.technology: devops-cicd-tasks
       -Arg2 val2 `
       -Arg3 val3
     azurePowerShellVersion: latestVersion
+    pwsh: true
 ```


### PR DESCRIPTION
Hi,

The [current documentation about](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/azure-powershell?view=azure-devops) the Azure PowerShell task is still using version 4, while version 5 is not in preview anymore an it is the latest version. 

Additionally, the documentation is missing the `pwsh` argument, this is important if you want to run you script on [PowerShell Core](https://github.com/PowerShell/PowerShell#-powershell) (you should!). Giving a version number with the other parameters doesn't work. This PR addresses #7434

Furthermore, #9723 describes also that the list of installed modules is outdated, so changed that and created a link to the hosted agents page. The list there is always (should be) up to date.

----
**Added** 
Fixes https://github.com/MicrosoftDocs/azure-devops-docs/issues/7434
Fixes https://github.com/MicrosoftDocs/azure-devops-docs/issues/9723
