### PR TITLE
updating classification nodes to 10k

### DIFF
--- a/docs/organizations/settings/work/object-limits.md
+++ b/docs/organizations/settings/work/object-limits.md
@@ -72,8 +72,8 @@ When working with teams, work item tags, backlogs, and boards, the following ope
 | Taskboard | 1,000 tasks  | 
 | Teams | 5,000 per project | 
 | Work item tags | 150,000 tag definitions per organization or collection | 
-| Area Paths | 300 per project
-| Iteration Paths | 300 per project
+| Area Paths | 10,000 per project
+| Iteration Paths | 10,000 per project
 
 Each backlog can display up to 10,000 work items. This is a limit on what the backlog can display, not a limit on the number of work items you can define. If your backlog exceeds this limit, then you may want to consider adding a team and moving some of the work items to the other team's backlog.
 


### PR DESCRIPTION
tested over 10k iterations
areas is currently on 3.5k but the tech is the same under the hood so should match

![image](https://user-images.githubusercontent.com/5680199/107082221-870b0d00-67fc-11eb-8973-e7b14ec805dc.png)
