### PR TITLE
Update multi-repo-checkout.md

### DIFF
--- a/docs/pipelines/repos/multi-repo-checkout.md
+++ b/docs/pipelines/repos/multi-repo-checkout.md
@@ -8,7 +8,7 @@ monikerRange: "> azure-devops-2019"
 
 # Check out multiple repositories in your pipeline
 
-[!INCLUDE [version-team-services](../includes/version-server-2020-rtm.md)]
+[!INCLUDE [version-team-services](../includes/version-team-services.md)]
 
 Pipelines often rely on multiple repositories that contain source, tools, scripts, or other items that you need to build your code. By using multiple `checkout` steps in your pipeline, you can fetch and check out other repositories in addition to the one you use to store your YAML pipeline.
 


### PR DESCRIPTION
Updated:

[!INCLUDE [version-team-services](../includes/version-server-2020-rtm.md)]

To 

[!INCLUDE [version-team-services](../includes/version-team-services.md)]

Because currently, multiple repositories is supported only for Services and customers are creating cases because this isn't working for Servers.