### PR TITLE
Correct QnA enablement key

### DIFF
--- a/docs/extend/develop/manifest.md
+++ b/docs/extend/develop/manifest.md
@@ -182,7 +182,7 @@ For a different experience than one of the default options use the **CustomerQnA
 ```json
 {
     "CustomerQnASupport": {
-        "enableqna": true,
+        "enablemarketplaceqna": true,
         "url": "http://uservoice.visualstudio.com"
     } 
 }
@@ -192,7 +192,7 @@ For a different experience than one of the default options use the **CustomerQnA
 
 Properties for the Customer Q & A Support section:
 
-- **enableqna** - boolean field, set to true for marketplace or custom Q&A; false for disabling Q&A
+- **enablemarketplaceqna** - boolean field, set to true for marketplace or custom Q&A; false for disabling Q&A
 - **url** - string, URL for custom Q&A
 
 
@@ -203,7 +203,7 @@ Properties for the Customer Q & A Support section:
 ```json
 {
      "CustomerQnASupport": {
-        "enableqna":"true",
+        "enablemarketplaceqna":"true",
         "url": "http://uservoice.visualstudio.com"
     } 
 }
@@ -213,7 +213,7 @@ Properties for the Customer Q & A Support section:
 ```json
 {
      "CustomerQnASupport": {
-        "enableqna":"true"
+        "enablemarketplaceqna":"true"
     } 
 }
 ```
@@ -222,7 +222,7 @@ Properties for the Customer Q & A Support section:
 ```json
 {
      "CustomerQnASupport": {
-        "enableqna":"false"
+        "enablemarketplaceqna":"false"
     } 
 }
 ```


### PR DESCRIPTION
Creating this PR to correct the extension manifest key name from `enableqna` to `enablemarketplaceqna`.