### PR TITLE
Example NuGet custom fixed

### DIFF
--- a/docs/pipelines/tasks/package/nuget.md
+++ b/docs/pipelines/tasks/package/nuget.md
@@ -201,7 +201,7 @@ Run any other NuGet command besides the default ones: pack, push, and restore.
   displayName: 'list locals'
   inputs:
     command: custom
-    arguments: 'nuget locals all -list'
+    arguments: 'locals all -list'
 ```
 ## Open-source
 


### PR DESCRIPTION
Example gave command `nuget nuget` on Azure DevOps Server 2020

```
D:\_2\_tool\NuGet\5.4.0\x64\nuget.exe nuget install XXX -NonInteractive
NuGet.CommandLine.CommandLineException: Unknown command: 'nuget'
   at NuGet.CommandLine.CommandManager.GetCommand(String commandName)
   at NuGet.CommandLine.CommandLineParser.ParseCommandLine(IEnumerable`1 commandLineArgs)
   at NuGet.CommandLine.Program.MainCore(String workingDirectory, String[] args)
Unknown command: 'nuget'
##[error]The nuget command failed with exit code(1) and error(Unknown command: 'nuget')
```