### PR TITLE
includes/PAT: Fix `Use a PAT` example in Bash

### DIFF
--- a/docs/repos/git/includes/personal-access-tokens.md
+++ b/docs/repos/git/includes/personal-access-tokens.md
@@ -135,7 +135,7 @@ On Linux or macOS, in Bash, you can enter:
  
 ```bash
 MY_PAT=yourPAT		# replace "yourPAT" with your actual PAT
-B64_PAT=$(printf -n":$MY_PAT" | base64)
+B64_PAT=$(printf %s ":$MY_PAT" | base64)
 git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone https://dev.azure.com/yourOrgName/yourProjectName/_git/yourRepoName
 ```
 


### PR DESCRIPTION
In commit 3055c788bfaef1391e3d8690cc1630180989710b, a bad rebase seems
to have led to a broken shell example (a stray `-n` was added, probably
from `echo -n`). Also, since PAT can theoretically include characters
which have special meaning to `printf`, the example wasn't 100% correct
to begin with.

Fix both issues by removing `-n` and using a constant format string with
`printf`.