### PR TITLE
Removing a Rogue Anchor Tag

### DIFF
--- a/docs/extend/extension-report.md
+++ b/docs/extend/extension-report.md
@@ -59,8 +59,6 @@ This tab gives you snapshot of all questions by your extension users with the no
 
 All data elements available in the reports page are also available for download in XLS format to aid creating your own custom reports. 
 
-<a id="contact" />
-
 ## Contact
 
 For paid extensions, you can use the <strong>Contact</strong> action to communicate with your users. This functionality is available only for publishers with contributor + access on the extension. 


### PR DESCRIPTION
This page had an anchor tag that was causing all text after it to be treated as a link.

![image](https://user-images.githubusercontent.com/7254163/111167125-29927a80-8577-11eb-881b-2f0d8547103f.png)
