### PR TITLE
Updating Authorization header from Basic to Bearer

### DIFF
--- a/docs/integrate/how-to/call-rest-api.md
+++ b/docs/integrate/how-to/call-rest-api.md
@@ -60,7 +60,7 @@ public static async void GetProjects()
 			client.DefaultRequestHeaders.Accept.Add(
 				new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
 
-			client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic",
+			client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer",
 				Convert.ToBase64String(
 					System.Text.ASCIIEncoding.ASCII.GetBytes(
 						string.Format("{0}:{1}", "", personalaccesstoken))));

--- a/docs/integrate/how-to/call-rest-api.md
+++ b/docs/integrate/how-to/call-rest-api.md
@@ -43,7 +43,7 @@ curl -u {username}[:{personalaccesstoken}] https://dev.azure.com/{organization}/
 If you wish to provide the personal access token through an HTTP header, you must first convert it to a Base64 string (the following example shows how to convert to Base64 using C#).  The resulting string can then be provided as an HTTP header in the format:
 
 ```
-Authorization: Basic BASE64PATSTRING
+Authorization: Bearer BASE64PATSTRING
 ``` 
 <br />
 Here it is in C# using the <a href="/previous-versions/visualstudio/hh193681(v=vs.118)" data-raw-source="[HttpClient class](/previous-versions/visualstudio/hh193681(v=vs.118))">HttpClient class</a>.


### PR DESCRIPTION
I'm currently going through [these docs](https://docs.microsoft.com/en-us/azure/devops/integrate/how-to/call-rest-api?view=azure-devops) on utilizing a PAT for the Azure DevOps REST APIs. 

In the docs, it gives an example of how to use the PAT in an HTTP header. The example says to use `Authorization: Basic` but that gives me a 401 Unauthorized error. However, changing it to `Authorization: Bearer` works correctly and gives me the 200 OK response.

I validated this by running both the provided sample code snippet and by using Postman. 