### PR TITLE
Remove redundant info from KubernetesManifest docs

### DIFF
--- a/docs/pipelines/tasks/deploy/kubernetes-manifest.md
+++ b/docs/pipelines/tasks/deploy/kubernetes-manifest.md
@@ -61,7 +61,7 @@ The following list shows the key benefits of this task:
     <td><b>action</b><br/>Action</td>
     <td>(Required)<br/>
     <br/>
-    Acceptable values are <b>deploy</b>, <b>promote</b>, <b>reject</b>, <b>bake</b>, <b>createSecret</b>, <b>scale</b>, <b>patch</b>, and <b>delete</b>.</td>
+    <b>deploy</b></td>
   </tr>
   <tr>
     <td><b>kubernetesServiceConnection</b><br/>Kubernetes service connection</td>
@@ -193,7 +193,7 @@ In the above example, the task tries to find matches for the images <code>foo/de
     <td><b>action</b><br/>Action</td>
     <td>(Required)<br/>
     <br/>
-    Acceptable values are <b>deploy</b>, <b>promote</b>, <b>reject</b>, <b>bake</b>, <b>createSecret</b>, <b>scale</b>, <b>patch</b>, and <b>delete</b>.</td>
+    <b>promote</b> or <b>reject</b></td>
   </tr>
   <tr>
     <td><b>kubernetesServiceConnection</b><br/>Kubernetes service connection</td>
@@ -246,11 +246,11 @@ In the above example, the task tries to find matches for the images <code>foo/de
     <td><b>action</b><br/>Action</td>
     <td>(Required)<br/>
     <br/>
-    Acceptable values are <b>deploy</b>, <b>promote</b>, <b>reject</b>, <b>bake</b>, <b>createSecret</b>, <b>scale</b>, <b>patch</b>, and <b>delete</b>.</td>
+    <b>createSecret</b></td>
   </tr>
   <tr>
     <td><b>secretType</b><br/>Secret type</td>
-    <td>(Required only if <b>action</b> is set to <b>createSecret</b>)<br/>
+    <td>(Required)<br/>
     <br/>
     Acceptable values are <b>dockerRegistry</b> and <b>generic</b>. The default value is <b>dockerRegistry</b>.<br/>
     <br/>
@@ -264,13 +264,13 @@ In the above example, the task tries to find matches for the images <code>foo/de
   </tr>
   <tr>
     <td><b>dockerRegistryEndpoint</b><br/>Docker registry service connection</td>
-    <td>(Required only if <b>action</b> is set to <b>createSecret</b> and <b>secretType</b> is set to <b>dockerRegistry</b>)<br/>
+    <td>(Required only if <b>secretType</b> is set to <b>dockerRegistry</b>)<br/>
     <br/>
     The credentials of the specified service connection are used to create a Docker registry secret within the cluster. Manifest files under the <b>imagePullSecrets</b> field can then refer to this secret's name.</td>
   </tr>
   <tr>
     <td><b>secretArguments</b><br/>Secret arguments</td>
-    <td>(Required only if <b>action</b> is set to <b>createSecret</b> and <b>secretType</b> is set to <b>generic</b>)<br/>
+    <td>(Required only if <b>secretType</b> is set to <b>generic</b>)<br/>
     <br/>
     Multiline input that accepts keys and literal values to be used for creation and updating of secrets. Here's an example:<br/>
     <b>--from-literal=key1=value1</b>
@@ -334,11 +334,11 @@ steps:
     <td><b>action</b><br/>Action</td>
     <td>(Required)<br/>
     <br/>
-    Acceptable values are <b>deploy</b>, <b>promote</b>, <b>reject</b>, <b>bake</b>, <b>createSecret</b>, <b>scale</b>, <b>patch</b>, and <b>delete</b>.</td>
+    <b>bake</b></td>
   </tr>
   <tr>
     <td><b>renderType</b><br/>Render engine</td>
-    <td>(Required only if <b>action</b> is set to <b>bake</b>)<br/>
+    <td>(Required)<br/>
     <br/>
     The render type used to produce the manifest files.</br>
     </br>
@@ -346,19 +346,19 @@ steps:
   </tr>
   <tr>
     <td><b>helmChart</b><br/>Helm chart</td>
-    <td>(Required only if <b>action</b> is set to <b>bake</b> and <b>renderType</b> is set to <b>helm2</b>)<br/>
+    <td>(Required only if <b>renderType</b> is set to <b>helm2</b>)<br/>
     <br/>
     The path to the Helm chart used for baking.</td>
   </tr>
   <tr>
     <td><b>overrideFiles</b><br/>Override files</td>
-    <td>(Optional, and relevant only if <b>action</b> is set to <b>bake</b> and <b>renderType</b> is set to <b>helm2</b>)<br/>
+    <td>(Optional, and relevant only if <b>renderType</b> is set to <b>helm2</b>)<br/>
     <br/>
     Multiline input that accepts the path to the override files. The files are used when manifest files from Helm charts are baked.</td>
   </tr>
   <tr>
     <td><b>overrides</b><br/>Override values</td>
-    <td>(Optional, and relevant only if <b>action</b> is set to <b>bake</b> and <b>renderType</b> is set to <b>helm2</b>)<br/>
+    <td>(Optional, and relevant only if <b>renderType</b> is set to <b>helm2</b>)<br/>
     <br/>
     Additional override values that are used via the command-line switch <b>--set</b> when manifest files using Helm are baked.<br/>
     <br/>
@@ -366,19 +366,19 @@ steps:
   </tr>
   <tr>
     <td><b>releaseName</b><br/>Release name</td>
-    <td>(Optional, and relevant only if <b>action</b> is set to <b>bake</b> and <b>renderType</b> is set to <b>helm2</b>)<br/>
+    <td>(Optional, and relevant only if <b>renderType</b> is set to <b>helm2</b>)<br/>
     <br/>
     The name of the release used when baking Helm charts.</td>
   </tr>
   <tr>
     <td><b>kustomizationPath</b><br/>Kustomization path</td>
-    <td>(Optional, and relevant only if <b>action</b> is set to <b>bake</b> and <b>renderType</b> is set to <b>kustomize</b>)<br/>
+    <td>(Optional, and relevant only if <b>renderType</b> is set to <b>kustomize</b>)<br/>
     <br/>
     The path to the directory containing the file kustomization.yaml.</td>
   </tr>
   <tr>
     <td><b>dockerComposeFile</b><br/>Path to Docker compose file</td>
-    <td>(Optional, and relevant only if <b>action</b> is set to <b>bake</b> and <b>renderType</b> is set to <b>kompose</b>)<br/>
+    <td>(Optional, and relevant only if <b>renderType</b> is set to <b>kompose</b>)<br/>
     <br/>
     The path to the Docker compose file.</td>
   </tr>
@@ -419,7 +419,7 @@ steps:
     <td><b>action</b><br/>Action</td>
     <td>(Required)<br/>
     <br/>
-    Acceptable values are <b>deploy</b>, <b>promote</b>, <b>reject</b>, <b>bake</b>, <b>createSecret</b>, <b>scale</b>, <b>patch</b>, and <b>delete</b>.</td>
+    <b>scale</b></td>
   </tr>
   <tr>
     <td><b>kind</b><br/>Kind</td>
@@ -480,7 +480,7 @@ steps:
     <td><b>action</b><br/>Action</td>
     <td>(Required)<br/>
     <br/>
-    Acceptable values are <b>deploy</b>, <b>promote</b>, <b>reject</b>, <b>bake</b>, <b>createSecret</b>, <b>scale</b>, <b>patch</b>, and <b>delete</b>.</td>
+    <b>patch</b></td>
   </tr>
   <tr>
     <td><b>resourceToPatch</b><br/>Resource to patch</td>
@@ -501,13 +501,13 @@ steps:
   </tr>
   <tr>
     <td><b>kind</b><br/>Kind</td>
-    <td>(Required only if <b>action</b> is set to <b>patch</b> and <b>resourceToPatch</b> is set to <b>name</b>)<br/>
+    <td>(Required only if <b>resourceToPatch</b> is set to <b>name</b>)<br/>
     <br/>
     The kind of the Kubernetes object. Examples include ReplicaSet and StatefulSet.</td>
   </tr>
   <tr>
     <td><b>name</b><br/>Name</td>
-    <td>(Required only if <b>action</b> is set to <b>patch</b> and <b>resourceToPatch</b> is set to <b>name</b>)<br/>
+    <td>(Required only if <b>resourceToPatch</b> is set to <b>name</b>)<br/>
     <br/>
     The name of the Kubernetes object to be patched.</td>
   </tr>
@@ -568,7 +568,7 @@ steps:
     <td><b>action</b><br/>Action</td>
     <td>(Required)<br/>
     <br/>
-    Acceptable values are <b>deploy</b>, <b>promote</b>, <b>reject</b>, <b>bake</b>, <b>createSecret</b>, <b>scale</b>, <b>patch</b>, and <b>delete</b>.</td>
+    <b>delete</b></td>
   </tr>
   <tr>
     <td><b>arguments</b><br/>Arguments</td>


### PR DESCRIPTION
This commit removes multiple references to "Acceptable values" that are not relevant for the reader.

This PR supersedes #7841

**Before**

``` markdown
## Deploy action

| Parameter | Description                                                                                 |
|-----------|---------------------------------------------------------------------------------------------|
| action    | Acceptable values are deploy, promote, reject, bake, createSecret, scale, patch, and delete |

## Create secret action

| Parameter  | Description                                                                                                                             |
|------------|-----------------------------------------------------------------------------------------------------------------------------------------|
| action     | Acceptable values are deploy, promote, reject, bake, createSecret, scale, patch, and delete                                             |
| secretType | (Required only if action is set to createSecret) Acceptable values are dockerRegistry and generic. The default value is dockerRegistry. |

## Bake action

| Parameter  | Description                                                                                  |
|------------|----------------------------------------------------------------------------------------------|
| action     | Acceptable values are deploy, promote, reject, bake, createSecret, scale, patch, and delete  |
| renderType | (Required only if action is set to bake) The render type used to produce the manifest files. |
```

**After**

``` markdown
## Deploy action

| Parameter | Description |
|-----------|-------------|
| action    | deploy      |

## Create secret action

| Parameter  | Description                                                                                       |
|------------|---------------------------------------------------------------------------------------------------|
| action     | createSecret                                                                                      |
| secretType | (Required) Acceptable values are dockerRegistry and generic. The default value is dockerRegistry. |

## Bake action

| Parameter  | Description                                                    |
|------------|----------------------------------------------------------------|
| action     | bake                                                           |
| renderType | (Required) The render type used to produce the manifest files. |
```

@juliakm @ktoliver 