### PR TITLE
Update `Recursive expansion` section

### DIFF
--- a/docs/pipelines/process/variables.md
+++ b/docs/pipelines/process/variables.md
@@ -1095,7 +1095,6 @@ If the variable `a` is an output variable from a previous job, then you can use 
 ### Recursive expansion
 
 On the agent, variables referenced using `$( )` syntax are recursively expanded.
-However, for service-side operations such as setting display names, variables aren't expanded recursively.
 For example:
 
 ```yaml
@@ -1105,7 +1104,7 @@ variables:
 
 steps:
 - script: echo $(myOuter)  # prints "someValue"
-  displayName: Variable is $(myOuter)  # display name is "Variable is $(myInner)"
+  displayName: Variable is $(myOuter)  # display name is "Variable is someValue"
 ```
 
 ::: moniker-end


### PR DESCRIPTION
Something clearly changed because following pipeline

```yaml
variables:
  myInner: someValue
  myOuter: $(myInner)

steps:
- script: echo $(myOuter)  # prints "someValue"
  displayName: Variable is $(myOuter)  # display name is "Variable is someValue"
  
- script: echo $(myOuter)  # prints "someValue"
  displayName: Variable is ${{ variables.myOuter }}  # display name is "Variable is someValue"
```

produce this `Variable is someValue`

![2021-03-25_01h36_56](https://user-images.githubusercontent.com/1680172/112401395-bc1ae280-8d0a-11eb-9927-1edeb9fc57fa.png)
