### PR TITLE
Fixes #10452. 

### DIFF
--- a/docs/pipelines/tasks/build/maven.md
+++ b/docs/pipelines/tasks/build/maven.md
@@ -99,7 +99,7 @@ The build agent must have the following capability:
     </tr>
     <tr>
        <td><code>jdkVersion</code><br/>JDK version</td>
-       <td>(Optional) Will attempt to discover the path to the selected JDK version and set JAVA_HOME accordingly. <br/>Default value: default <br/>Argument aliases: <code>jdkVersionOption</code></td>
+       <td>(Optional) Will attempt to discover the path to the selected JDK version and set JAVA_HOME accordingly.<br/><strong>Note:</strong> If running on an agent not hosted by Microsoft, and the requested Java version is not the one indicated by the JAVA_HOME variable set on the agent machine, the task will rely on the variable <code>JAVA_HOME_&lt;version&gt;_&lt;arch&gt;</code> (e.g. <code>JAVA_HOME_8_X64</code>), to locate the necessary JDK. Ensure this variable is set on self-hosted agents for any version and architecture of the JDK that may be requested by this parameter and/or by <code>jdkArchitecture</code>.<br/>Default value: default <br/>Argument aliases: <code>jdkVersionOption</code></td>
     </tr>
     <tr>
        <td><code>jdkUserInputPath</code><br/>JDK path</td>
@@ -107,7 +107,7 @@ The build agent must have the following capability:
     </tr>
     <tr>
        <td><code>jdkArchitecture</code><br/>JDK architecture</td>
-       <td>(Optional) Optionally supply the architecture (x86, x64) of the JDK. <br/>Default value: x64 <br/>Argument aliases: <code>jdkArchitectureOption</code></td>
+       <td>(Optional) Optionally supply the architecture (x86, x64) of the JDK. <br/><strong>Note:</strong> If running on an agent not hosted by Microsoft, and the requested Java architecture is not the one indicated by the JAVA_HOME variable set on the agent machine, the task will rely on the variable <code>JAVA_HOME_&lt;version&gt;_&lt;arch&gt;</code> (e.g. <code>JAVA_HOME_8_X64</code>), to locate the necessary JDK. Ensure this variable is set on self-hosted agents for any version and architecture of the JDK that may be requested by this parameter and/or by <code>jdkVersion</code>.<br/>Default value: x64 <br/>Argument aliases: <code>jdkArchitectureOption</code></td>
     </tr>
     <tr>
        <td><code>mavenVersionSelection</code><br/>Maven version</td>


### PR DESCRIPTION
Adding instructions for supporting multiple JDK versions and architectures on self-hosted agents with Maven task.