### PR TITLE
Use https://api.ipify.org instead of http://checkip.dyndns.com to get $agentIP

### DIFF
--- a/docs/pipelines/targets/azure-sqldb.md
+++ b/docs/pipelines/targets/azure-sqldb.md
@@ -83,7 +83,7 @@ param
   [String] [Parameter(Mandatory = $true)] $ResourceGroup,
   [String] $AzureFirewallName = "AzureWebAppFirewall"
 )
-$agentIP = (New-Object net.webclient).downloadstring("https://api.ipify.org/")
+$agentIP = (New-Object net.webclient).downloadstring("https://api.ipify.org")
 New-AzSqlServerFirewallRule -ResourceGroupName $ResourceGroup -ServerName $ServerName -FirewallRuleName $AzureFirewallName -StartIPAddress $agentIp -EndIPAddress $agentIP
 ```
 
@@ -101,11 +101,11 @@ param
 $ErrorActionPreference = 'Stop'
 
 function New-AzureSQLServerFirewallRule {
-  $agentIP = (New-Object net.webclient).downloadstring("https://api.ipify.org/")
+  $agentIP = (New-Object net.webclient).downloadstring("https://api.ipify.org")
   New-AzureSqlDatabaseServerFirewallRule -StartIPAddress $agentIp -EndIPAddress $agentIp -FirewallRuleName $AzureFirewallName -ServerName $ServerName -ResourceGroupName $ResourceGroupName
 }
 function Update-AzureSQLServerFirewallRule{
-  $agentIP= (New-Object net.webclient).downloadstring("https://api.ipify.org/")
+  $agentIP= (New-Object net.webclient).downloadstring("https://api.ipify.org")
   Set-AzureSqlDatabaseServerFirewallRule -StartIPAddress $agentIp -EndIPAddress $agentIp -FirewallRuleName $AzureFirewallName -ServerName $ServerName -ResourceGroupName $ResourceGroupName
 }
 

--- a/docs/pipelines/targets/azure-sqldb.md
+++ b/docs/pipelines/targets/azure-sqldb.md
@@ -83,7 +83,7 @@ param
   [String] [Parameter(Mandatory = $true)] $ResourceGroup,
   [String] $AzureFirewallName = "AzureWebAppFirewall"
 )
-$agentIP = (New-Object net.webclient).downloadstring("http://checkip.dyndns.com") -replace "[^\d\.]"
+$agentIP = (New-Object net.webclient).downloadstring("https://api.ipify.org/")
 New-AzSqlServerFirewallRule -ResourceGroupName $ResourceGroup -ServerName $ServerName -FirewallRuleName $AzureFirewallName -StartIPAddress $agentIp -EndIPAddress $agentIP
 ```
 
@@ -101,11 +101,11 @@ param
 $ErrorActionPreference = 'Stop'
 
 function New-AzureSQLServerFirewallRule {
-  $agentIP = (New-Object net.webclient).downloadstring("http://checkip.dyndns.com") -replace "[^\d\.]"
+  $agentIP = (New-Object net.webclient).downloadstring("https://api.ipify.org/")
   New-AzureSqlDatabaseServerFirewallRule -StartIPAddress $agentIp -EndIPAddress $agentIp -FirewallRuleName $AzureFirewallName -ServerName $ServerName -ResourceGroupName $ResourceGroupName
 }
 function Update-AzureSQLServerFirewallRule{
-  $agentIP= (New-Object net.webclient).downloadstring("http://checkip.dyndns.com") -replace "[^\d\.]"
+  $agentIP= (New-Object net.webclient).downloadstring("https://api.ipify.org/")
   Set-AzureSqlDatabaseServerFirewallRule -StartIPAddress $agentIp -EndIPAddress $agentIp -FirewallRuleName $AzureFirewallName -ServerName $ServerName -ResourceGroupName $ResourceGroupName
 }
 


### PR DESCRIPTION
Advantages of using https://api.ipify.org instead of http://checkip.dyndns.com:

* `checkip.dyndns.com` does not support HTTPS and times out when hitting https://checkip.dyndns.com on a browser or using netcat, for example: `nc -v checkip.dyndns.com 443` times out.
* https://www.ipify.org is an OSS project [maintained in GitHub](https://github.com/rdegges/ipify-api), funded by Randall Degges and hosted in Heroku so it should be as reliable as http://checkip.dyndns.com
* No need to `-replace "[^\d\.]"` since their API returns the caller IP in plaintext.

Confirmed using Powershell `GetType()` that the resulting value of `$agentIP` is the same type as before:

Using http://checkip.dyndns.com
```powershell
$agentIP = (New-Object net.webclient).downloadstring("http://checkip.dyndns.com") -replace "[^\d\.]"

$agentIP.GetType()

IsPublic IsSerial Name                                     BaseType
-------- -------- ----                                     --------
True     True     String                                   System.Object
```

Using https://api.ipify.org: 
```powershell
$agentIP = (New-Object net.webclient).downloadstring("https://api.ipify.org")

$agentIP.GetType()

IsPublic IsSerial Name                                     BaseType
-------- -------- ----                                     --------
True     True     String                                   System.Object
```

