### PR TITLE
Removed note about preinstalled Boost for Microsoft-hosted agents

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -365,13 +365,6 @@ If you get an SAS error code, it is most likely because the IP address ranges fr
   .NET Core 2.2.105 is default on VM images but Mono version 6.0 or greater requires .NET Core 2.2.300+. 
   If you use the Mono 6.0 or greater, you will have to override .NET Core version using [.NET Core Tool Installer task](../tasks/tool/dotnet-core-tool-installer.md).
 
-#### Boost
-  The VM images contain prebuilt Boost libraries with their headers in the directory designated by `BOOST_ROOT` environment variable. In order to include the Boost headers, the path `$BOOST_ROOT/include` should be added to the search paths.
-  
-  Example of g++ invocation with Boost libraries:
-  ```
-  g++ -I "$BOOST_ROOT/include" ...
-  ```
 ## Videos 
 > [!VIDEO https://www.youtube.com/embed/A8f_05lnfe0?start=0]
 


### PR DESCRIPTION
Hi!

We recently removed Boost from Ubuntu and WIndows images completely in https://github.com/actions/virtual-environments/issues/2667, so this note is not needed anymore. I am removing it in this PR.

Please, take a look. Thanks!