### PR TITLE
Update hosted.md and build-image.md

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -323,11 +323,13 @@ If you get an SAS error code, it is most likely because the IP address ranges fr
 
 #### Xamarin
 
-  To manually select a Xamarin SDK version to use on the **Hosted macOS** agent, before your Xamarin build task, execute this command line as part of your build, replacing the Mono version number 5.4.1 as needed (also replacing '.' characters with underscores: '_'). Choose the Mono version that is associated with the Xamarin SDK version that you need.
+  To manually select a Xamarin SDK version to use on the **Hosted macOS** agent, before your Xamarin build task, execute this command line as part of your build, specifying the symlink to Xamarin versions bundle as needed.
 
-  `/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 5_4_1"`
+  `/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh <symlink>"`
 
-  Mono versions associated with Xamarin SDK versions on the **Hosted macOS** agent can be found [here](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.14-Readme.md).
+  The list of all available Xamarin SDK versions and symlinks can be found in these documentations:
+  - [macOS 10.15](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xamarin)
+  - [macOS 11.0](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11.0-Readme.md#xamarin)
 
   This command does not select the Mono version beyond the Xamarin SDK. To manually select a Mono version, see instructions below.
 
@@ -361,17 +363,6 @@ If you get an SAS error code, it is most likely because the IP address ranges fr
   echo "##vso[task.setvariable variable=PATH;]$MONOPREFIX/bin:$PATH"
 ```
 
-#### .NET Core
-  .NET Core 2.2.105 is default on VM images but Mono version 6.0 or greater requires .NET Core 2.2.300+. 
-  If you use the Mono 6.0 or greater, you will have to override .NET Core version using [.NET Core Tool Installer task](../tasks/tool/dotnet-core-tool-installer.md).
-
-#### Boost
-  The VM images contain prebuilt Boost libraries with their headers in the directory designated by `BOOST_ROOT` environment variable. In order to include the Boost headers, the path `$BOOST_ROOT/include` should be added to the search paths.
-  
-  Example of g++ invocation with Boost libraries:
-  ```
-  g++ -I "$BOOST_ROOT/include" ...
-  ```
 ## Videos 
 > [!VIDEO https://www.youtube.com/embed/A8f_05lnfe0?start=0]
 

--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -323,11 +323,13 @@ If you get an SAS error code, it is most likely because the IP address ranges fr
 
 #### Xamarin
 
-  To manually select a Xamarin SDK version to use on the **Hosted macOS** agent, before your Xamarin build task, execute the following bash command as a part of your build, specifying the symlink to Xamarin versions bundle as needed.
+  **Hosted macOS** agent stores Xamarin SDK versions and the accosiated Mono versions as a set of symlinks to Xamarin SDK locations that are available by a single bundle symlink.
+
+  To manually select a Xamarin SDK version to use on the **Hosted macOS** agent, execute the following bash command before your Xamarin build task as a part of your build, specifying the symlink to Xamarin versions bundle that you need.
 
   `/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh <symlink>"`
 
-  The list of all available Xamarin SDK versions and symlinks can be found in these documentations:
+  The list of all available Xamarin SDK versions and symlinks can be found in the agents documentations:
   - [macOS 10.14](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.14-Readme.md#xamarin)
   - [macOS 10.15](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xamarin)
 
@@ -353,7 +355,7 @@ If you get an SAS error code, it is most likely because the IP address ranges fr
 
 #### Mono
 
-  To manually select a Mono version to use on the **Hosted macOS** agent pool, before your Mono build task, execute this script in each job of your build, specifying the symlink with the required Mono version (the link to the list of all available symlinks can be found in Xamarin section above):
+  To manually select a Mono version to use on the **Hosted macOS** agent pool, execute this script in each job of your build before your Mono build task, specifying the symlink with the required Mono version (list of all available symlinks can be found in the [Xamarin section](#xamarin) above):
 
   ```bash
   SYMLINK=<symlink>

--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -323,7 +323,7 @@ If you get an SAS error code, it is most likely because the IP address ranges fr
 
 #### Xamarin
 
-  To manually select a Xamarin SDK version to use on the **Hosted macOS** agent, before your Xamarin build task, execute this command line as part of your build, specifying the symlink to Xamarin versions bundle as needed.
+  To manually select a Xamarin SDK version to use on the **Hosted macOS** agent, before your Xamarin build task, execute the following bash command as a part of your build, specifying the symlink to Xamarin versions bundle as needed.
 
   `/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh <symlink>"`
 

--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -329,7 +329,7 @@ If you get an SAS error code, it is most likely because the IP address ranges fr
 
   `/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh <symlink>"`
 
-  The list of all available Xamarin SDK versions and symlinks can be found in the agents documentations:
+  The list of all available Xamarin SDK versions and symlinks can be found in the agents documentation:
   - [macOS 10.14](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.14-Readme.md#xamarin)
   - [macOS 10.15](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xamarin)
 

--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -328,8 +328,8 @@ If you get an SAS error code, it is most likely because the IP address ranges fr
   `/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh <symlink>"`
 
   The list of all available Xamarin SDK versions and symlinks can be found in these documentations:
+  - [macOS 10.14](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.14-Readme.md#xamarin)
   - [macOS 10.15](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xamarin)
-  - [macOS 11.0](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11.0-Readme.md#xamarin)
 
   This command does not select the Mono version beyond the Xamarin SDK. To manually select a Mono version, see instructions below.
 
@@ -353,10 +353,10 @@ If you get an SAS error code, it is most likely because the IP address ranges fr
 
 #### Mono
 
-  To manually select a Mono version to use on the **Hosted macOS** agent pool, before your Mono build task, execute this script in each job of your build, replacing the Mono version number 5.4.1 as needed:
+  To manually select a Mono version to use on the **Hosted macOS** agent pool, before your Mono build task, execute this script in each job of your build, specifying the symlink with the required Mono version (the link to the list of all available symlinks can be found in Xamarin section above):
 
   ```bash
-  SYMLINK=5_4_1
+  SYMLINK=<symlink>
   MONOPREFIX=/Library/Frameworks/Mono.framework/Versions/$SYMLINK
   echo "##vso[task.setvariable variable=DYLD_FALLBACK_LIBRARY_PATH;]$MONOPREFIX/lib:/lib:/usr/lib:$DYLD_LIBRARY_FALLBACK_PATH"
   echo "##vso[task.setvariable variable=PKG_CONFIG_PATH;]$MONOPREFIX/lib/pkgconfig:$MONOPREFIX/share/pkgconfig:$PKG_CONFIG_PATH"

--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -339,15 +339,15 @@ If you get an SAS error code, it is most likely because the IP address ranges fr
 
   `/bin/bash -c "echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'$(xcodeRoot);sudo xcode-select --switch $(xcodeRoot)/Contents/Developer"`
   
-  where `$(xcodeRoot)` = `/Applications/Xcode_10.1.app`
+  where `$(xcodeRoot)` = `/Applications/Xcode_12.4.app`
 
   Xcode versions on the **Hosted macOS** agent pool can be found [here](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode).
 
 #### Xcode
 
-  If you use the [Xcode task](../tasks/build/xcode.md) included with Azure Pipelines and TFS, you can select a version of Xcode in that task's properties. Otherwise, to manually set the Xcode version to use on the **Hosted macOS** agent pool, before your `xcodebuild` build task, execute this command line as part of your build, replacing the Xcode version number 8.3.3 as needed:
+  If you use the [Xcode task](../tasks/build/xcode.md) included with Azure Pipelines and TFS, you can select a version of Xcode in that task's properties. Otherwise, to manually set the Xcode version to use on the **Hosted macOS** agent pool, before your `xcodebuild` build task, execute this command line as part of your build, replacing the Xcode version number 12.4 as needed:
 
-  `/bin/bash -c "sudo xcode-select -s /Applications/Xcode_8.3.3.app/Contents/Developer"`
+  `/bin/bash -c "sudo xcode-select -s /Applications/Xcode_12.4.app/Contents/Developer"`
 
   Xcode versions on the **Hosted macOS** agent pool can be found [here](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode).
 

--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -323,7 +323,7 @@ If you get an SAS error code, it is most likely because the IP address ranges fr
 
 #### Xamarin
 
-  **Hosted macOS** agent stores Xamarin SDK versions and the accosiated Mono versions as a set of symlinks to Xamarin SDK locations that are available by a single bundle symlink.
+  **Hosted macOS** agent stores Xamarin SDK versions and the associated Mono versions as a set of symlinks to Xamarin SDK locations that are available by a single bundle symlink.
 
   To manually select a Xamarin SDK version to use on the **Hosted macOS** agent, execute the following bash command before your Xamarin build task as a part of your build, specifying the symlink to Xamarin versions bundle that you need.
 

--- a/docs/pipelines/ecosystems/containers/build-image.md
+++ b/docs/pipelines/ecosystems/containers/build-image.md
@@ -76,7 +76,7 @@ If you're not going to continue to use this application, delete your pipeline an
 
 ### What pre-cached images are available on hosted agents?
 
-Some commonly used images are pre-cached on the Microsoft-hosted agents to avoiding long time intervals spent in pulling these images from container registry for every job. Some popular images are pre-cached on Windows and Ubuntu agents. The list of pre-cached images is available in the [release notes of azure-pipelines-image-generation](https://github.com/actions/virtual-environments/releases) repository.
+Some commonly used images are pre-cached on the Microsoft-hosted agents to avoiding long time intervals spent in pulling these images from container registry for every job. The list of pre-cached images is available in the [release notes of azure-pipelines-image-generation](https://github.com/actions/virtual-environments/releases) repository.
 
 ### How do I set the BuildKit variable for my docker builds?
 

--- a/docs/pipelines/ecosystems/containers/build-image.md
+++ b/docs/pipelines/ecosystems/containers/build-image.md
@@ -76,7 +76,7 @@ If you're not going to continue to use this application, delete your pipeline an
 
 ### What pre-cached images are available on hosted agents?
 
-Some commonly used images are pre-cached on the Microsoft-hosted agents to avoiding long time intervals spent in pulling these images from container registry for every job. The list of pre-cached images is available in the [release notes of azure-pipelines-image-generation](https://github.com/actions/virtual-environments/releases) repository.
+Some commonly used images are pre-cached on Microsoft-hosted agents to avoid long time intervals spent in pulling these images from the container registry for every job. The list of pre-cached images is available in the [release notes of azure-pipelines-image-generation](https://github.com/actions/virtual-environments/releases) repository.
 
 ### How do I set the BuildKit variable for my docker builds?
 

--- a/docs/pipelines/ecosystems/containers/build-image.md
+++ b/docs/pipelines/ecosystems/containers/build-image.md
@@ -76,7 +76,7 @@ If you're not going to continue to use this application, delete your pipeline an
 
 ### What pre-cached images are available on hosted agents?
 
-Some commonly used images are pre-cached on the Microsoft-hosted agents to avoiding long time intervals spent in pulling these images from container registry for every job. Images such as `microsoft/dotnet-framework`, `microsoft/aspnet`, `microsoft/windowsservercore`, `microsoft/nanoserver`, and `microsoft/aspnetcore-build` are pre-cached on Windows agents while `jekyll/builder` and `mcr.microsoft.com/azure-pipelines/node8-typescript` are pre-cached on Linux agents. The list of pre-cached images is available in the [release notes of azure-pipelines-image-generation](https://github.com/actions/virtual-environments/releases) repository.
+Some commonly used images are pre-cached on the Microsoft-hosted agents to avoiding long time intervals spent in pulling these images from container registry for every job. Images such as `microsoft/dotnet-framework`, `microsoft/aspnet`, `microsoft/windowsservercore`, `microsoft/nanoserver`, and `microsoft/aspnetcore-build` are pre-cached on Windows agents. The list of pre-cached images is available in the [release notes of azure-pipelines-image-generation](https://github.com/actions/virtual-environments/releases) repository.
 
 ### How do I set the BuildKit variable for my docker builds?
 


### PR DESCRIPTION
**hosted.md:** 
- Updated Xamarin section due to changes in Xamarin documentation of virtual-environments (https://github.com/actions/virtual-environments/pull/3113)
- Removed outdated `Boost` and `.NET Core` sections

**build-image.md:**
- The `jekyll/builder` and `mcr.microsoft.com/azure-pipelines/node8-typescript` Docker images were removed from Ubuntu images. Please find details in this announcement https://github.com/actions/virtual-environments/issues/2958