### PR TITLE
Fix #10487 about Dead link to the command reference

### DIFF
--- a/docs/cli/toc.yml
+++ b/docs/cli/toc.yml
@@ -21,7 +21,7 @@
 - name: Azure CLI Reference
   items:
   - name: Command reference
-    href: /cli/azure/ext/azure-devops?view=azure-cli-latest
+    href: https://docs.microsoft.com/cli/azure/devops?view=azure-cli-latest
   - name: Output formats
     href: /cli/azure/format-output-azure-cli?view=azure-cli-latest
   - name: Query


### PR DESCRIPTION
Fix #10487

The link is now pointing to `az devops` CLI reference landing page