### PR TITLE
Reverted to use yaml snippet for PublishCodeCoverageResultsV1

### DIFF
--- a/docs/pipelines/tasks/includes/yaml/PublishCodeCoverageResultsV1.md
+++ b/docs/pipelines/tasks/includes/yaml/PublishCodeCoverageResultsV1.md
@@ -10,7 +10,7 @@ ms.technology: devops-cicd-tasks
 ```YAML
 # Publish code coverage results
 # Publish Cobertura or JaCoCo code coverage results from a build
-- task: PublishCodeCoverageResults@2
+- task: PublishCodeCoverageResults@1
   inputs:
     summaryFileLocation: 
     #pathToSources: # Optional

--- a/docs/pipelines/tasks/test/publish-code-coverage-results.md
+++ b/docs/pipelines/tasks/test/publish-code-coverage-results.md
@@ -35,7 +35,7 @@ To generate the HTML code coverage report you need dotnet 2.0.0 or later on the 
 
 ## YAML snippet
 
-[!INCLUDE [temp](../includes/yaml/PublishCodeCoverageResultsV2.md)]
+[!INCLUDE [temp](../includes/yaml/PublishCodeCoverageResultsV1.md)]
 
 The **codeCoverageTool** and **summaryFileLocation** parameters are mandatory. 
 


### PR DESCRIPTION
**Issue:**
The PublishCodeCoverageResultsV2 task is not released, so we should not be using the YAML snippet link for PublishCodeCoverageResultsV2 in public docs.

**Fix:**
Reverted to use yaml snippet for PublishCodeCoverageResultsV1