### PR TITLE
Adding note to associating builds to manual test results

### DIFF
--- a/docs/test/reference-qa.md
+++ b/docs/test/reference-qa.md
@@ -313,7 +313,7 @@ with the selected build, and the test outcome will be published
 against that build.
 
 > [!NOTE]
-> The selected build should be from the same project were the tests are defined.
+> The selected build must be from the same project where the tests are defined.
 
 ### Q: Can I fix my test steps while I'm running a test?
 

--- a/docs/test/reference-qa.md
+++ b/docs/test/reference-qa.md
@@ -312,6 +312,8 @@ Any bug filed during the run will automatically be associated
 with the selected build, and the test outcome will be published
 against that build.
 
+[!NOTE] The selected build should be from the same project were the tests are defined.
+
 ### Q: Can I fix my test steps while I'm running a test?
 
 **A:** Yes, if you have Azure Test Plans for Azure DevOps. 

--- a/docs/test/reference-qa.md
+++ b/docs/test/reference-qa.md
@@ -313,7 +313,7 @@ with the selected build, and the test outcome will be published
 against that build.
 
 > [!NOTE]
-> The selected build must be from the same project where the tests are defined.
+> The selected build must be from the project in which the tests are defined.
 
 ### Q: Can I fix my test steps while I'm running a test?
 

--- a/docs/test/reference-qa.md
+++ b/docs/test/reference-qa.md
@@ -312,7 +312,8 @@ Any bug filed during the run will automatically be associated
 with the selected build, and the test outcome will be published
 against that build.
 
-[!NOTE] The selected build should be from the same project were the tests are defined.
+> [!NOTE]
+> The selected build should be from the same project were the tests are defined.
 
 ### Q: Can I fix my test steps while I'm running a test?
 


### PR DESCRIPTION
The note is related to DTS https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1834314 .
While waiting for the fix to be published the public documentation should clearly identify this limitation.