### PR TITLE
Include information about updating environment variable capabilities

### DIFF
--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -144,8 +144,8 @@ The agent software automatically determines various system capabilities such as 
 
 > [!Note]
 >
-> The storing of environment variables as capabilites means when a agent runs the stored capability values are used to set the environment variables. This means that any changes to environment variables whilst the agent is running, will be not be picked up and used by any task.
-> If you have sensitive environment variables that change and you need to not be statically stored as capabilities you can have them ignored by setting the `VSO_AGENT_IGNORE` environment variable with a comma delimited list of variables to ignore. `PATH` is a critical variable that if you are installing software you may want to ignore.   
+> The storing of environment variables as capabilites means that when an agent runs, the stored capability values are used to set the environment variables. This means that any changes to environment variables while the agent is running will be not be picked up and used by any task.
+> If you have sensitive environment variables that change, and you don't wish them to be stored as capabilities, you can have them ignored by setting the `VSO_AGENT_IGNORE` environment variable with a comma delimited list of variables to ignore. `PATH` is a critical variable that if you are installing software you may want to ignore.   
 
 When you author a pipeline you specify certain **demands** of the agent. The system sends the job only to agents that have capabilities matching the [demands](../process/demands.md) specified in the pipeline. As a result, agent capabilities allow you to direct jobs to specific agents.
 

--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -142,12 +142,10 @@ Every self-hosted agent has a set of capabilities that indicate what it can do. 
 
 The agent software automatically determines various system capabilities such as the name of the machine, type of operating system, and versions of certain software installed on the machine. Also, environment variables defined in the machine automatically appear in the list of system capabilities.
 
-> [!Note]
->
-> The storing of environment variables as capabilites means that when an agent runs, the stored capability values are used to set the environment variables. This means that any changes to environment variables while the agent is running will be not be picked up and used by any task.
-> If you have sensitive environment variables that change, and you don't wish them to be stored as capabilities, you can have them ignored by setting the `VSO_AGENT_IGNORE` environment variable with a comma delimited list of variables to ignore. `PATH` is a critical variable that if you are installing software you may want to ignore.   
+> [!NOTE]
+> Storing environment variables as capabilites means that when an agent runs, the stored capability values are used to set the environment variables. Also, any changes to environment variables that are made while the agent is running won't be picked up and used by any task. If you have sensitive environment variables that change and you don't want them to be stored as capabilities, you can have them ignored by setting the `VSO_AGENT_IGNORE` environment variable, with a comma-delimited list of variables to ignore. For example, `PATH` is a critical variable that you might want to ignore if you're installing software.   
 
-When you author a pipeline you specify certain **demands** of the agent. The system sends the job only to agents that have capabilities matching the [demands](../process/demands.md) specified in the pipeline. As a result, agent capabilities allow you to direct jobs to specific agents.
+When you author a pipeline, you specify certain **demands** of the agent. The system sends the job only to agents that have capabilities matching the [demands](../process/demands.md) specified in the pipeline. As a result, agent capabilities allow you to direct jobs to specific agents.
 
 > [!NOTE]
 >

--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -142,6 +142,11 @@ Every self-hosted agent has a set of capabilities that indicate what it can do. 
 
 The agent software automatically determines various system capabilities such as the name of the machine, type of operating system, and versions of certain software installed on the machine. Also, environment variables defined in the machine automatically appear in the list of system capabilities.
 
+> [!Note]
+>
+> The storing of environment variables as capabilites means when a agent runs the stored capability values are used to set the environment variables. This means that any changes to environment variables whilst the agent is running, will be not be picked up and used by any task.
+> If you have sensitive environment variables that change and you need to not be statically stored as capabilities you can have them ignored by setting the `VSO_AGENT_IGNORE` environment variable with a comma delimited list of variables to ignore. `PATH` is a critical variable that if you are installing software you may want to ignore.   
+
 When you author a pipeline you specify certain **demands** of the agent. The system sends the job only to agents that have capabilities matching the [demands](../process/demands.md) specified in the pipeline. As a result, agent capabilities allow you to direct jobs to specific agents.
 
 > [!NOTE]

--- a/docs/pipelines/agents/includes/capabilities.md
+++ b/docs/pipelines/agents/includes/capabilities.md
@@ -17,6 +17,6 @@ For example, if your build includes the [npm task](../../tasks/package/npm.md), 
 
 > [!IMPORTANT]
 > 
-> Capabilities includes all environment variables and their values that are set when the agent runs. If any of these values change whilst the agent is running the agent needs to be restarted to pick uo the new values. This is why after you install new software on an agent, you must restart the agent for the new capability to show up in the pool so that the build can run.
+> Capabilities includes all environment variables and their values that are set when the agent runs. If any of these values change while the agent is running, the agent must be restarted to pick up the new values. After you install new software on an agent, you must restart the agent for the new capability to show up in the pool, so that the build can run.
 > 
-> if you want environment variables not to be included as capabilities you can have them ignored by setting an enirvonment vairable `VSO_AGENT_IGNORE` with a comma delimited list of variables to ignore. 
+> If you want to exclude environment variables as capabilities, you can designate them by setting an enirvonment vairable `VSO_AGENT_IGNORE` with a comma delimited list of variables to ignore. 

--- a/docs/pipelines/agents/includes/capabilities.md
+++ b/docs/pipelines/agents/includes/capabilities.md
@@ -16,7 +16,6 @@ In many cases, after you deploy an agent, you'll need to install software or uti
 For example, if your build includes the [npm task](../../tasks/package/npm.md), then the build won't run unless there's a build agent in the pool that has npm installed.
 
 > [!IMPORTANT]
+> Capabilities include all environment variables and the values that are set when the agent runs. If any of these values change while the agent is running, the agent must be restarted to pick up the new values. After you install new software on an agent, you must restart the agent for the new capability to show up in the pool, so that the build can run.
 > 
-> Capabilities includes all environment variables and their values that are set when the agent runs. If any of these values change while the agent is running, the agent must be restarted to pick up the new values. After you install new software on an agent, you must restart the agent for the new capability to show up in the pool, so that the build can run.
-> 
-> If you want to exclude environment variables as capabilities, you can designate them by setting an enirvonment vairable `VSO_AGENT_IGNORE` with a comma delimited list of variables to ignore. 
+> If you want to exclude environment variables as capabilities, you can designate them by setting an enirvonment vairable `VSO_AGENT_IGNORE` with a comma-delimited list of variables to ignore. 

--- a/docs/pipelines/agents/includes/capabilities.md
+++ b/docs/pipelines/agents/includes/capabilities.md
@@ -9,7 +9,7 @@ ms.date: 02/12/2020
 
 ## Capabilities
 
-Your agent's capabilities are cataloged and advertised in the pool so that only the builds and releases it can handle are assigned to it. See [Build and release agent capabilities](../agents.md#capabilities).
+Your agent's capabilities are cataloged and advertised in the pool so that only the builds and releases it can handle are assigned to it. See [Build and release agent capabilities](../agents.md#capabilities). 
 
 In many cases, after you deploy an agent, you'll need to install software or utilities. Generally you should install on your agents whatever software and tools you use on your development machine.
 
@@ -17,4 +17,6 @@ For example, if your build includes the [npm task](../../tasks/package/npm.md), 
 
 > [!IMPORTANT]
 > 
-> After you install new software on an agent, you must restart the agent for the new capability to show up in the pool so that the build can run.
+> Capabilities includes all environment variables and their values that are set when the agent runs. If any of these values change whilst the agent is running the agent needs to be restarted to pick uo the new values. This is why after you install new software on an agent, you must restart the agent for the new capability to show up in the pool so that the build can run.
+> 
+> if you want environment variables not to be included as capabilities you can have them ignored by setting an enirvonment vairable `VSO_AGENT_IGNORE` with a comma delimited list of variables to ignore. 


### PR DESCRIPTION
Storing PATH as a capability means its static and the agent needs restarting to get updated values. There is no means to update restart an agent through automation and thus exlcuding path from capabilties should be done. 

Documenting use of VSO_AGENT_IGNORE to allow for path to be ignored. 

https://github.com/microsoft/azure-pipelines-agent/issues/3367