### PR TITLE
Added an environments section in the 'windows pipeline agents'

### DIFF
--- a/docs/pipelines/agents/includes/v2/unattended-config.md
+++ b/docs/pipelines/agents/includes/v2/unattended-config.md
@@ -59,3 +59,8 @@ name in the format `domain\userName` or `userName@domain.com`
 - `--addDeploymentGroupTags` - used with `--deploymentGroup` to indicate that deployment group tags should be added
 - `--deploymentGroupTags <tags>` - used with `--addDeploymentGroupTags` to specify the comma separated list of tags for
 the deployment group agent - for example "web, db"
+
+### Environments only
+- `--addvirtualmachineresourcetags` - used to indicate that environment resource tags should be added
+- `--virtualmachineresourcetags  <tags>` - used with `--addvirtualmachineresourcetags` to specify the comma separated list of tags for
+the environment resource agent - for example "web, db"


### PR DESCRIPTION
added an environments section in the 'windows pipeline agents', and described the virtual machine resource tags parameters that can be used when setting up the agent. 

Done based on this stackoverflow post:

https://stackoverflow.com/questions/66870474/specifying-the-tags-on-the-environment-during-environment-creation