### PR TITLE
Suggestions for Docker for linux

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -343,7 +343,7 @@ Now that you have created an image, you can run a container.
     docker run -e AZP_URL=<Azure DevOps instance> -e AZP_TOKEN=<PAT token> -e AZP_AGENT_NAME=mydockeragent dockeragent:latest
     ```
 
-If you want a fresh agent container for every pipeline job, pass the [`--once` flag](v2-linux.md#run-once) to the `run` command.
+   If you want a fresh agent container for every pipeline job, pass the [`--once` flag](v2-linux.md#run-once) to the `run` command.
 
     ```shell
     docker run -e AZP_URL=<Azure DevOps instance> -e AZP_TOKEN=<PAT token> -e AZP_AGENT_NAME=mydockeragent dockeragent:latest --once


### PR DESCRIPTION
Goal of this PR:
- allow the agent to be removed from ADO when finishing (`trap 'cleanup; exit 0' EXIT`)
- allow all arguments to be passed to the run command (such as the `--once` flag)
- set a fix agent version in the docker image, so that the script only configures the agent for an organization
- install the az cli by default:
  >Microsoft hosted agents have Azure CLI pre-installed. However if you are using private agents, install Azure CLI on the computer(s) that run the build and release agent. If an agent is already running on the machine on which the Azure CLI is installed, restart the agent to ensure all the relevant stage variables are updated.

Additional notes:
- it would be great to have this image available in MCR so that we don't have to build it