### PR TITLE
Improve agent cleanup

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -271,10 +271,15 @@ Next, create the Dockerfile.
     cleanup() {
       if [ -e config.sh ]; then
         print_header "Cleanup. Removing Azure Pipelines agent..."
+        
+        # If the agent has some running jobs, the configuration removal process will fail.
+        # So, give it some time to finish the job.
+        while true; do
+          ./config.sh remove --unattended --auth PAT --token $(cat "$AZP_TOKEN_FILE") && break
 
-        ./config.sh remove --unattended \
-          --auth PAT \
-          --token $(cat "$AZP_TOKEN_FILE")
+          echo "Retrying in 30 seconds..."
+          sleep 30
+        done
       fi
     }
 


### PR DESCRIPTION
Azure Pipelines Agent, which gets removed from Azure DevOps on SIGINT and SIGTERM, throws the following error in case it is running some job:
```
Error reported in diagnostic logs. Please examine the log for more details.
    - /azp/agent/_diag/Agent_20210422-070016-utc.log
Failed: Removing agent from the server
Agent "<agent_name>" is running a job for pool "<pool_name>"
```

Container gets deleted, without Azure DevOps being aware of it - leading to failing pipeline.