### PR TITLE
Fix typo in comparison-git-tfvc.md

### DIFF
--- a/docs/repos/tfvc/comparison-git-tfvc.md
+++ b/docs/repos/tfvc/comparison-git-tfvc.md
@@ -82,7 +82,7 @@ Need more help to make a choice? These charts might help.
 <td>
 <p>Path-based branches are used mostly as long-standing constructs to isolate risk of change among feature teams and releases. Team members typically set up an additional workspace for each branch they work on.</p>
 
-<p>Changes in each branch are independent from each other, so you don&#39;t have to check them in before switching from one branch to another. Merging between sibling branches requires a baseless merging.
+<p>Changes in each branch are independent from each other, so you don&#39;t have to check them in before switching from one branch to another. Merging between sibling branches requires a baseless merge.
 </p>
 
 <p>You can get visualizations of your branch structures and where your changesets have been merged.</p>


### PR DESCRIPTION
The sentence:

> Merging between sibling branches requires a baseless merging.

Should read:

> Merging between sibling branches requires a baseless merge.

...or even:

> Merging between sibling branches requires baseless merging.

I chose the first variant above, because the docs on the [TFVC Merge Command](https://docs.microsoft.com/en-us/azure/devops/repos/tfvc/merge-command?view=azure-devops) seem to prefer the words "baseless merge".

PS: it might be handy to link to the [Baseless Merge](https://docs.microsoft.com/en-us/azure/devops/repos/tfvc/merge-command?view=azure-devops#baseless-merge) section to help those like me who have never used TFVC and were curious how it differs with Git.