### PR TITLE
Fix another typo in comparison-git-tfvc.md

### DIFF
--- a/docs/repos/tfvc/comparison-git-tfvc.md
+++ b/docs/repos/tfvc/comparison-git-tfvc.md
@@ -160,7 +160,7 @@ Need more help to make a choice? These charts might help.
 <tr>
 <td>Auditability</td>
 <td>Because your team checks in all their work into a centralized system, you can identify which user checked in a <a href="find-view-changesets.md" data-raw-source="[changeset](find-view-changesets.md)">changeset</a> and use <a href="compare-files.md" data-raw-source="[compare](compare-files.md)">compare</a> to see what they changed. Looking at a file, you can <a href="view-file-changes-using-annotate.md" data-raw-source="[annotate](view-file-changes-using-annotate.md)">annotate</a> it to identify who changed a block of code, and when they did it.</td>
-<td>You can identify which user pushed a commit. (Anyone can claim any identity as the author or committer.) You can identify when changes were made what was changed using history, compare, and annotate.</td>
+<td>You can identify which user pushed a commit. (Anyone can claim any identity as the author or committer.) You can identify when changes were made and what was changed using history, compare, and annotate.</td>
 </tr>
 <tr>
 <td>Builds (automated by TFBuild)</td>


### PR DESCRIPTION
The sentence:

> You can identify when changes were made what was changed...

...is missing the word **and**...it should read:

> You can identify when changes were made **and** what was changed...