### PR TITLE
Typo - Related Articles - Scrum best practices -> Added new bullet point

### DIFF
--- a/docs/boards/sprints/task-board.md
+++ b/docs/boards/sprints/task-board.md
@@ -348,7 +348,8 @@ Work with [sprint burndown](../../report/dashboards/configure-sprint-burndown.md
 As you can see, the Taskboard provides a lot of support for your Scrum activities. For related topics, see:
 
 - [Assign backlog items to a sprint](assign-work-sprint.md)  
-- [Interactively filter backlogs, boards, queries, and plans](../backlogs/filter-backlogs-boards-plans.md)[Scrum best practices](best-practices-scrum.md)
+- [Interactively filter backlogs, boards, queries, and plans](../backlogs/filter-backlogs-boards-plans.md)
+- [Scrum best practices](best-practices-scrum.md)
 - [Sprint planning](assign-work-sprint.md)
 - [Schedule sprints](define-sprints.md)
 - [Customize a sprint Taskboard](customize-taskboard.md)


### PR DESCRIPTION
[https://docs.microsoft.com/en-us/azure/devops/boards/sprints/task-board?view=azure-devops#related-articles](https://docs.microsoft.com/en-us/azure/devops/boards/sprints/task-board?view=azure-devops#related-articles)

Created another bullet point for the "Scrum best practices" link.