### PR TITLE
Add details about hash kind for Incoming Webhook

### DIFF
--- a/release-notes/2020/includes/pipelines/sprint-172-update.md
+++ b/release-notes/2020/includes/pipelines/sprint-172-update.md
@@ -41,8 +41,8 @@ Here are the steps to configure the webhook triggers:
     - Secret - This is optional. If you need to secure your JSON payload, provide the **Secret** value
 2. Create a new "Incoming Webhook" service connection. This is a newly introduced Service Connection Type that will allow you to define three important pieces of information:
     - **Webhook Name**: The name of the webhook should match webhook created in your external service.
-    - **HTTP Header** - The name of the HTTP header in the request that contains the payload hash value for request verification. For example, in the case of the GitHub, the request header will be "**X-Hub-Signature**"
-    - **Secret** - The secret is used to parse the payload hash used for verification of the incoming request (this is optional). If you have used a secret in creating your webhook, you will need to provide the same secret key  
+    - **HTTP Header** - The name of the HTTP header in the request that contains the payload's HMAC-SHA1 hash value for request verification. For example, in the case of the GitHub, the request header will be "**X-Hub-Signature**"
+    - **Secret** - The secret is used to verify the payload's HMAC-SHA1 hash used for verification of the incoming request (this is optional). If you have used a secret in creating your webhook, you will need to provide the same secret key  
 
     :::image type="content" source="../../media/172-pipelines-0-1.png" alt-text="In the Edit service connection page, configure webhook triggers.":::
 


### PR DESCRIPTION
Nowhere does it specify the hash method (HMAC-SHA1) for incoming webhooks. This is intended to correct that.

Fixes https://github.com/MicrosoftDocs/azure-devops-docs/issues/8913