### PR TITLE
I lost some of the runs. Is there any way to get them back?  - paragraph

### DIFF
--- a/docs/pipelines/policies/retention.md
+++ b/docs/pipelines/policies/retention.md
@@ -475,9 +475,9 @@ As the stage is deleted, so the stage level retention settings are not applicabl
 
 The only way to retain a run or a release longer than what is allowed through retention settings is to manually mark it to be retained indefinitely. There is no way to configure a longer retention setting. You can also explore the possibility of using the REST APIs in order to download information and artifacts about the runs and upload them to your own storage or artifact repository.
 
-### I lost some of the runs. Is there any way to get them back?
+### I lost some runs. Is there a way to get them back?
 
-If you believe that you have lost the runs due to a bug in the service, then create a support ticket immediately to recover the lost information.If the runs have been manually deleted longer than a week ago then it is not possible to recover the lost runs. If the runs have been deleted as expected due to a retention policy it is not possible to recover the lost runs. 
+If you believe that you have lost runs due to a bug in the service, create a support ticket immediately to recover the lost information. If the runs were manually deleted more than a week earlier, it isn't possible to recover the lost runs. If the runs were deleted as expected due to a retention policy, it isn't possible to recover the lost runs. 
 
 
 ### How do I use the `Build.Cleanup` capability of agents?

--- a/docs/pipelines/policies/retention.md
+++ b/docs/pipelines/policies/retention.md
@@ -477,7 +477,8 @@ The only way to retain a run or a release longer than what is allowed through re
 
 ### I lost some of the runs. Is there any way to get them back?
 
-If you believe that you have lost the runs due to a bug in the service, then create a support ticket immediately to recover the lost information. If the runs have been deleted as expected due to a retention policy or if the runs have been deleted longer than a week ago, then it is not possible to recover the lost runs.
+If you believe that you have lost the runs due to a bug in the service, then create a support ticket immediately to recover the lost information.If the runs have been manually deleted longer than a week ago then it is not possible to recover the lost runs. If the runs have been deleted as expected due to a retention policy it is not possible to recover the lost runs. 
+
 
 ### How do I use the `Build.Cleanup` capability of agents?
 


### PR DESCRIPTION
While troubleshooting a case, i have stumbled upon the misunderstanding that can come out of the paragraph mentioned in the title.
I would like to make clear differentiation between the fact that runs that have been deleted by retention policies they cannot be recovered and the fact that if the pipeline deletion has passed a week it is also not possible to have it recovered.
Also, an important aspect to note is that pipeline deletions that have passed a week, must be manual, otherwise the retention policy not being able to recover gets trumped by the fact that only one week has passed. For this reason i have added the "manually" , in the phrase addressing this.

Please correct me if i am wrong.