### PR TITLE
Removed reference to "team rooms"

### DIFF
--- a/docs/service-hooks/create-subscription.md
+++ b/docs/service-hooks/create-subscription.md
@@ -23,7 +23,6 @@ Supported events:
 - pull request create or updated (for Git projects)
 - code checked in (TFVC projects)
 - work item created, updated, deleted, restored or commented on
-- message posted to a team room
 
 You can configure filters on your subscriptions to control which events trigger an action. For example, you can filter the build completed event based on the build status. For a complete set of supported events and filter options, see the [event reference](./events.md).
 


### PR DESCRIPTION
This is to resolve #10594.

As "team rooms" have been deprecated a while ago on both Server and Service, this PR is removing that reference.
