### PR TITLE
Fix typo in Build.ArtifactStagingDirectory

### DIFF
--- a/docs/pipelines/build/variables.md
+++ b/docs/pipelines/build/variables.md
@@ -23,7 +23,7 @@ These variables are automatically set by the system and read-only. (The exceptio
 
 ::: moniker range=">=azure-devops-2020"
 
-In YAML pipelines, you can reference predefined variables as environment variables. For example, the variable `Build.ArtfactStagingDirectory` becomes the variable `BUILD_ARTIFACTSTAGINGDIRECTORY`.
+In YAML pipelines, you can reference predefined variables as environment variables. For example, the variable `Build.ArtifactStagingDirectory` becomes the variable `BUILD_ARTIFACTSTAGINGDIRECTORY`.
 
 For classic pipelines, you can use [release variables](../release/variables.md) in your deploy tasks to share the common information (e.g. — Environment Name, Resource Group, etc).
 


### PR DESCRIPTION
Fixes a small typo in `variables.md`. Issue: #10762