### PR TITLE
Improved example for generalSettings parameter (AzureAppServiceSettings).

### DIFF
--- a/docs/pipelines/tasks/deploy/azure-app-service-settings.md
+++ b/docs/pipelines/tasks/deploy/azure-app-service-settings.md
@@ -73,14 +73,8 @@ steps:
     generalSettings: |
       [
         {
-          "name": "WEBAPP_NAME",
-          "value": "$(WebApp_Name)",
-          "slotSetting": false
-        },
-        {
-          "name": "WEBAPP_PLAN_NAME",
-          "value": "$(WebApp_PlanName)",
-          "slotSetting": false
+          "alwaysOn": true,
+          "webSocketsEnabled": false
         }
       ]
     connectionStrings: |


### PR DESCRIPTION
The example given for this parameter did not match the proper usage, so I have taken a better example directly from [the repository readme file](https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/AzureAppServiceSettingsV1/README.md).