### PR TITLE
Added tip to omit project name in repo URLs

### DIFF
--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -261,6 +261,9 @@ We now have a private repository within Azure Artifacts that we can push our Pow
     ```
 
     > [!TIP]
+    > Omit `<project_name>/` from the URLs above if your Feed was created in the 'Organization' scope instead of the 'Project' scope
+   
+    > [!NOTE]
     > Certain versions of PowerShell requires restarting a new session after executing `Register-PSRepository` cmdlet to avoid the `Unable to resolve package source` warning. 
 
 4. To confirm that the repository was registered successfully run the `Get-PSRepository` cmdlet. This command gets all module repositories registered for the current user:

--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -248,14 +248,14 @@ We now have a private repository within Azure Artifacts that we can push our Pow
 3. Register your PowerShell repository. The `SourceLocation` link can also be found by selecting **Connect to Feed** then **NuGet.exe** from the feed's page in Azure Artifacts.
 
     > [!NOTE]
-    > For organization-scoped feeds, omit the `<project_name>` from the PublishLocation and SourceLocation URLs.
+    > For organization-scoped feeds, omit `<project_name>` from the PublishLocation and SourceLocation URLs.
 
     ```powershell
         Register-PSRepository -Name "PowershellAzureDevopsServices" -SourceLocation "https://pkgs.dev.azure.com/<org_name>/<project_name>/_packaging/<feed_name>/nuget/v2" -PublishLocation "https://pkgs.dev.azure.com/<org_name>/<project_name>/_packaging/<feed_name>/nuget/v2" -InstallationPolicy Trusted -Credential $credsAzureDevopsServices
     ```
     
     > [!IMPORTANT]
-    > PowerShell does not support Version 3 of NuGet.
+    > PowerShell does not support version 3 of NuGet.
     
     If you're still using the older `visualstudio.com` URLs, use the following command instead:
 
@@ -264,7 +264,7 @@ We now have a private repository within Azure Artifacts that we can push our Pow
     ```
    
     > [!NOTE]
-    > Certain versions of PowerShell requires restarting a new session after executing `Register-PSRepository` cmdlet to avoid the `Unable to resolve package source` warning. 
+    > In some versions of PowerShell, you must restart with a new session after you run the `Register-PSRepository` cmdlet to avoid the `Unable to resolve package source` warning. 
 
 4. To confirm that the repository was registered successfully run the `Get-PSRepository` cmdlet. This command gets all module repositories registered for the current user:
 

--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -247,6 +247,9 @@ We now have a private repository within Azure Artifacts that we can push our Pow
 
 3. Register your PowerShell repository. The `SourceLocation` link can also be found by selecting **Connect to Feed** then **NuGet.exe** from the feed's page in Azure Artifacts.
 
+    > [!NOTE]
+    > For organization-scoped feeds, omit the `<project_name>` from the PublishLocation and SourceLocation URLs.
+
     ```powershell
         Register-PSRepository -Name "PowershellAzureDevopsServices" -SourceLocation "https://pkgs.dev.azure.com/<org_name>/<project_name>/_packaging/<feed_name>/nuget/v2" -PublishLocation "https://pkgs.dev.azure.com/<org_name>/<project_name>/_packaging/<feed_name>/nuget/v2" -InstallationPolicy Trusted -Credential $credsAzureDevopsServices
     ```
@@ -259,9 +262,6 @@ We now have a private repository within Azure Artifacts that we can push our Pow
     ```powershell
         Register-PSRepository -Name "PowershellAzureDevopsServices" -SourceLocation "https://<org_name>.pkgs.visualstudio.com/<project_name>/_packaging/<feed_name>/nuget/v2" -PublishLocation "https://<org_name>.pkgs.visualstudio.com/<project_name>/_packaging/<feed_name>/nuget/v2" -InstallationPolicy Trusted -Credential $credsAzureDevopsServices
     ```
-
-    > [!TIP]
-    > Omit `<project_name>/` from the URLs above if your Feed was created in the 'Organization' scope instead of the 'Project' scope
    
     > [!NOTE]
     > Certain versions of PowerShell requires restarting a new session after executing `Register-PSRepository` cmdlet to avoid the `Unable to resolve package source` warning. 


### PR DESCRIPTION
Added tip to omit project name in URLs for Organisation scoped feeds.
Adding `<project_name>/` to URL only applies to feeds created in Project scope - which is currently recommended, but it is still possible to create Organisation scoped feeds, which won't work.

Upgraded pre-existing, adjacent tip to note to give it precedence.

Relates to #8756