### PR TITLE
correct reference for runOnce-Strategy

### DIFF
--- a/docs/pipelines/process/deployment-jobs.md
+++ b/docs/pipelines/process/deployment-jobs.md
@@ -378,8 +378,8 @@ To share variables between stages, output an [artifact](../artifacts/pipeline-ar
 
 While executing deployment strategies, you can access output variables across jobs using the following syntax.
 
-- For **runOnce** strategy: `$[dependencies.<job-name>.outputs['<lifecycle-hookname>.<step-name>.<variable-name>']]` (e.g. `$[dependencies.JobA.outputs['Deploy.StepA.VariableA']]` )
-- For **runOnce** strategy plus a resourceType: `$[dependencies.<job-name>.outputs['<lifecycle-hookname>_<resource-name>.<step-name>.<variable-name>']]`. (e.g. `$[dependencies.JobA.outputs['Deploy_VM1.StepA.VariableA']]` )
+- For **runOnce** strategy: `$[dependencies.<job-name>.outputs['<lifecycle-hookname>.<step-name>.<variable-name>']]` (for example, `$[dependencies.JobA.outputs['Deploy.StepA.VariableA']]`)
+- For **runOnce** strategy plus a resourceType: `$[dependencies.<job-name>.outputs['<lifecycle-hookname>_<resource-name>.<step-name>.<variable-name>']]`. (for example, `$[dependencies.JobA.outputs['Deploy_VM1.StepA.VariableA']]`)
 - For **canary** strategy:  `$[dependencies.<job-name>.outputs['<lifecycle-hookname>_<increment-value>.<step-name>.<variable-name>']]`  
 - For **rolling** strategy: `$[dependencies.<job-name>.outputs['<lifecycle-hookname>_<resource-name>.<step-name>.<variable-name>']]`
 
@@ -535,5 +535,4 @@ Learn more about how to [set a multi-job output variable](variables.md#set-a-mul
 ### My pipeline is stuck with the message "Job is pending...". How can I fix this?
  
 This can happen when there is a name conflict between two jobs. Verify that any deployment jobs in the same stage have a unique name and that job and stage names do not contain keywords. If renaming does not fix the problem, review [troubleshooting pipeline runs](../troubleshooting/troubleshooting.md).
-
 

--- a/docs/pipelines/process/deployment-jobs.md
+++ b/docs/pipelines/process/deployment-jobs.md
@@ -378,8 +378,8 @@ To share variables between stages, output an [artifact](../artifacts/pipeline-ar
 
 While executing deployment strategies, you can access output variables across jobs using the following syntax.
 
-- For **runOnce** strategy: `$[dependencies.<job-name>.outputs['<job-name>.<step-name>.<variable-name>']]` 
-    - For deployment jobs using the **runOnce** strategy: `$[dependencies.<job-name>.outputs['<lifecycle-hookname>_<resource-name>.<step-name>.<variable-name>']]`. For example, if you have a deployment job to a virtual machine named `Vm1`, the output variable would be `$[dependencies.<job-name>.outputs['Deploy_vm1.<step-name>.<variable-name>']]`
+- For **runOnce** strategy: `$[dependencies.<job-name>.outputs['<lifecycle-hookname>.<step-name>.<variable-name>']]` (e.g. `$[dependencies.JobA.outputs['Deploy.StepA.VariableA']]` )
+- For **runOnce** strategy plus a resourceType: `$[dependencies.<job-name>.outputs['<lifecycle-hookname>_<resource-name>.<step-name>.<variable-name>']]`. (e.g. `$[dependencies.JobA.outputs['Deploy_VM1.StepA.VariableA']]` )
 - For **canary** strategy:  `$[dependencies.<job-name>.outputs['<lifecycle-hookname>_<increment-value>.<step-name>.<variable-name>']]`  
 - For **rolling** strategy: `$[dependencies.<job-name>.outputs['<lifecycle-hookname>_<resource-name>.<step-name>.<variable-name>']]`
 


### PR DESCRIPTION
Preferably examples for canary and rolling should be added, though I do not have them at this point in time