### PR TITLE
Update pipeline-artifacts.md

### DIFF
--- a/docs/pipelines/artifacts/pipeline-artifacts.md
+++ b/docs/pipelines/artifacts/pipeline-artifacts.md
@@ -10,6 +10,7 @@ monikerRange: 'azure-devops'
 "recommendations": "true"
 ---
 
+
 # Publish and download artifacts in Azure Pipelines
 
 **Azure Pipelines**


### PR DESCRIPTION
Publish and consume artifacts in pipelines - Azure Pipelines and TFS | Microsoft Docs:
This page is showing below Note when choosing Azure DevOps Server 2020 on the left:

"The requested page is not available for Azure DevOps Server 2020. You have been redirected to the newest product version this page is available for."

But this task is available in Azure DevOps Server 2020. The documentation for Publish Build Artifacts task says that this task is deprecated for TFS 2017 and newer and is recommending to use Publish Pipeline Artifact task:

https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/publish-build-artifacts?view=azure-devops-2020

Publish Build Artifacts task
12/07/2018
2 minutes to read
+11
Azure Pipelines | TFS 2018 | TFS 2017 | TFS 2015.3
Note
This task is deprecated. If you're using Team Foundation Server 2017 or newer, we recommend that you use Pipeline Artifacts.