### PR TITLE
Replace email with a link to form for free tier request

### DIFF
--- a/docs/pipelines/licensing/concurrent-jobs.md
+++ b/docs/pipelines/licensing/concurrent-jobs.md
@@ -38,7 +38,7 @@ You can buy additional private jobs from the Visual Studio Marketplace.
 Learn how to estimate how many parallel jobs you need and buy more parallel jobs for your organization. 
 
 > [!NOTE]
-> We have temporarily disabled the free grant of parallel jobs for public projects and for certain private projects in new organizations. However, you can request this grant However, you can request this grant by submitting a request through the following form: https://aka.ms/azpipelines-parallelism-request. Existing organizations and projects are not affected. Please note that it takes us 3-4 business days to respond to your free tier requests.
+> We have temporarily disabled the free grant of parallel jobs for public projects and for certain private projects in new organizations. However, you can request this grant by submitting a request through the following form: https://aka.ms/azpipelines-parallelism-request. Existing organizations and projects are not affected. Please note that it takes us 2-3 business days to respond to your free tier requests.
 
 ## What is a parallel job? 
 
@@ -70,7 +70,7 @@ To request the free grant for public or private projects, submit a request throu
 
 
 > [!NOTE] 
-> It takes us 3-4 business days to respond to your free tier request.
+> It takes us 2-3 business days to respond to your free tier request.
 
 There is no time limit on parallel jobs for public projects and a 30 hour time limit per month for private projects.
 

--- a/docs/pipelines/licensing/concurrent-jobs.md
+++ b/docs/pipelines/licensing/concurrent-jobs.md
@@ -38,7 +38,7 @@ You can buy additional private jobs from the Visual Studio Marketplace.
 Learn how to estimate how many parallel jobs you need and buy more parallel jobs for your organization. 
 
 > [!NOTE]
-> We have temporarily disabled the free grant of parallel jobs for public projects and for certain private projects in new organizations. However, you can request this grant by submitting a request through the following form: https://aka.ms/azpipelines-parallelism-request. Existing organizations and projects are not affected. Please note that it takes us 2-3 business days to respond to your free tier requests.
+> We have temporarily disabled the free grant of parallel jobs for public projects and for certain private projects in new organizations. However, you can request this grant However, you can request this grant by submitting a request through the following form: https://aka.ms/azpipelines-parallelism-request. Existing organizations and projects are not affected. Please note that it takes us 3-4 business days to respond to your free tier requests.
 
 ## What is a parallel job? 
 
@@ -70,7 +70,7 @@ To request the free grant for public or private projects, submit a request throu
 
 
 > [!NOTE] 
-> It takes us 2-3 business days to respond to your free tier request.
+> It takes us 3-4 business days to respond to your free tier request.
 
 There is no time limit on parallel jobs for public projects and a 30 hour time limit per month for private projects.
 

--- a/docs/pipelines/licensing/concurrent-jobs.md
+++ b/docs/pipelines/licensing/concurrent-jobs.md
@@ -38,7 +38,7 @@ You can buy additional private jobs from the Visual Studio Marketplace.
 Learn how to estimate how many parallel jobs you need and buy more parallel jobs for your organization. 
 
 > [!NOTE]
-> We have temporarily disabled the free grant of parallel jobs for public projects and for certain private projects in new organizations. However, you can request this grant by sending an email to azpipelines-freetier@microsoft.com. Existing organizations and projects are not affected. Please note that it takes us 2-3 business days to respond to your free tier requests.
+> We have temporarily disabled the free grant of parallel jobs for public projects and for certain private projects in new organizations. However, you can request this grant However, you can request this grant by submitting a request through the following form: https://aka.ms/azpipelines-parallelism-request. Existing organizations and projects are not affected. Please note that it takes us 3-4 business days to respond to your free tier requests.
 
 ## What is a parallel job? 
 
@@ -66,16 +66,11 @@ For Microsoft-hosted parallel jobs, you can get up to 10 free Microsoft-hosted p
 
 For **private projects**, you can get one free job that can run for up to 60 minutes each time. When you create a new Azure DevOps organization you may not always be given this free grant by default. 
 
-To request the free grant for public or private projects, send an email to azpipelines-freetier@microsoft.com and provide the following information:
+To request the free grant for public or private projects, submit a request through the following form: https://aka.ms/azpipelines-parallelism-request
 
-- Your name
-- The Azure DevOps organization for which you are seeking the free grant
-- Whether you need the free grant for public projects or private projects
-- (Public projects only) Links to public repositories that you plan to build
-- (Public projects only) A brief description of your project
 
 > [!NOTE] 
-> It takes us 2-3 business days to respond to your free tier request.
+> It takes us 3-4 business days to respond to your free tier request.
 
 There is no time limit on parallel jobs for public projects and a 30 hour time limit per month for private projects.
 

--- a/docs/pipelines/licensing/concurrent-jobs.md
+++ b/docs/pipelines/licensing/concurrent-jobs.md
@@ -38,7 +38,7 @@ You can buy additional private jobs from the Visual Studio Marketplace.
 Learn how to estimate how many parallel jobs you need and buy more parallel jobs for your organization. 
 
 > [!NOTE]
-> We have temporarily disabled the free grant of parallel jobs for public projects and for certain private projects in new organizations. However, you can request this grant by submitting a request through the following form: https://aka.ms/azpipelines-parallelism-request. Existing organizations and projects are not affected. Please note that it takes us 2-3 business days to respond to your free tier requests.
+> We have temporarily disabled the free grant of parallel jobs for public projects and for certain private projects in new organizations. However, you can request this grant by submitting [a request](https://aka.ms/azpipelines-parallelism-request). Existing organizations and projects are not affected. Please note that it takes us 2-3 business days to respond to your free tier requests.
 
 ## What is a parallel job? 
 
@@ -66,7 +66,7 @@ For Microsoft-hosted parallel jobs, you can get up to 10 free Microsoft-hosted p
 
 For **private projects**, you can get one free job that can run for up to 60 minutes each time. When you create a new Azure DevOps organization you may not always be given this free grant by default. 
 
-To request the free grant for public or private projects, submit a request through the following form: https://aka.ms/azpipelines-parallelism-request
+To request the free grant for public or private projects, submit [a request](https://aka.ms/azpipelines-parallelism-request).
 
 
 > [!NOTE] 


### PR DESCRIPTION
**Description**:
Since Azure DevOps is already directing customers to fill out a Microsoft Form to request free parallelism, we also should update the related docs as well. 

**Changes**:
- `azpipelines-freetier@microsoft.com` replaced with the link to the form: `https://aka.ms/azpipelines-parallelism-request`