### PR TITLE
1 user suggests update the Azure Pipelines agents overview document

### DIFF
--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -580,10 +580,21 @@ You might also run into problems if parallel build jobs are using the same singl
 
 ::: moniker range=">= azure-devops-2019"
 
-### What’s the behavior of DevOps agents when the pipeline jobs are cancelled?
+### What’s the behavior of agents when the pipeline jobs are cancelled?
 
-When Azure Devops cancels a pipeline step running on a Linux agent,  a SIGINT is sent first. If the step’s child process does not die 7.5 seconds after receiving the SIGINT a SIGTERM will be sent. If then the process does not die after 2.5 seconds the agent issues a SIGKILL to the process. Hence, a non-responsive child process will run for ten seconds before being killed.
+For Microsoft-hosted agents, the agent is torn down and returned to the Azure Pipelines pool.
 
+For self hosted agents:
+
+When a pipeline is cancelled, the agent sends a sequence of commands to the process executing the current step. The first command is sent with a timeout of 7.5 seconds. If the process has not terminated, a second command is sent with a timeout of 2.5 seconds. If the process has not terminated, the agent issues a command to kill the process. If the process does not honor the two initial termination requests, it will be killed. From the initial request to termination takes approximately 10 seconds.
+
+The commands issued to the process are different based on the agent operating system.
+
+* macoS and Linux - The commands sent are SIGINT, followed by SIGTERM, followed by SIGKILL.
+* Windows - THe commands sent to the process are Ctrl+C, followed by Ctrl+Break, followed by Process.Kill
+
+> [!NOTE]
+> Azure Pipelines Agent is open source on GitHub
 Source code reference: https://github.com/microsoft/azure-pipelines-agent
 
 ## Learn more

--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -580,6 +580,12 @@ You might also run into problems if parallel build jobs are using the same singl
 
 ::: moniker range=">= azure-devops-2019"
 
+### What’s the behavior of DevOps agents when the pipeline jobs are cancelled?
+
+When Azure Devops cancels a pipeline step running on a Linux agent,  a SIGINT is sent first. If the step’s child process does not die 7.5 seconds after receiving the SIGINT a SIGTERM will be sent. If then the process does not die after 2.5 seconds the agent issues a SIGKILL to the process. Hence, a non-responsive child process will run for ten seconds before being killed.
+
+Source code reference: https://github.com/microsoft/azure-pipelines-agent
+
 ## Learn more
 
 For more information about agents, see the following modules from the [Build applications with Azure DevOps](/learn/paths/build-applications-with-azure-devops/) learning path.

--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -594,8 +594,7 @@ The commands issued to the process are different based on the agent operating sy
 * Windows - THe commands sent to the process are Ctrl+C, followed by Ctrl+Break, followed by Process.Kill
 
 > [!NOTE]
-> Azure Pipelines Agent is open source on GitHub
-Source code reference: https://github.com/microsoft/azure-pipelines-agent
+> Azure Pipelines Agent is open source on GitHub. Source code reference: https://github.com/microsoft/azure-pipelines-agent
 
 ## Learn more
 

--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -590,8 +590,8 @@ When a pipeline is cancelled, the agent sends a sequence of commands to the proc
 
 The commands issued to the process are different based on the agent operating system.
 
-* macoS and Linux - The commands sent are SIGINT, followed by SIGTERM, followed by SIGKILL.
-* Windows - THe commands sent to the process are Ctrl+C, followed by Ctrl+Break, followed by Process.Kill
+* macOS and Linux - The commands sent are SIGINT, followed by SIGTERM, followed by SIGKILL.
+* Windows - THe commands sent to the process are Ctrl+C, followed by Ctrl+Break, followed by Process.Kill.
 
 > [!NOTE]
 > Azure Pipelines Agent is open source on GitHub. Source code reference: https://github.com/microsoft/azure-pipelines-agent

--- a/docs/pipelines/agents/agents.md
+++ b/docs/pipelines/agents/agents.md
@@ -584,18 +584,18 @@ You might also run into problems if parallel build jobs are using the same singl
 
 For Microsoft-hosted agents, the agent is torn down and returned to the Azure Pipelines pool.
 
-For self hosted agents:
+For self-hosted agents:
 
 When a pipeline is cancelled, the agent sends a sequence of commands to the process executing the current step. The first command is sent with a timeout of 7.5 seconds. If the process has not terminated, a second command is sent with a timeout of 2.5 seconds. If the process has not terminated, the agent issues a command to kill the process. If the process does not honor the two initial termination requests, it will be killed. From the initial request to termination takes approximately 10 seconds.
 
 The commands issued to the process are different based on the agent operating system.
 
 * macOS and Linux - The commands sent are SIGINT, followed by SIGTERM, followed by SIGKILL.
-* Windows - THe commands sent to the process are Ctrl+C, followed by Ctrl+Break, followed by Process.Kill.
+* Windows - The commands sent to the process are Ctrl+C, followed by Ctrl+Break, followed by Process.Kill.
 
 > [!NOTE]
-> Azure Pipelines Agent is open source on GitHub. Source code reference: https://github.com/microsoft/azure-pipelines-agent
-
+> Azure Pipelines Agent is open source on [GitHub](https://github.com/microsoft/azure-pipelines-agent).
+> 
 ## Learn more
 
 For more information about agents, see the following modules from the [Build applications with Azure DevOps](/learn/paths/build-applications-with-azure-devops/) learning path.


### PR DESCRIPTION
The customers who are making secondary development, want to know the behavior of DevOps agents when the pipeline jobs are cancelled.