### PR TITLE
Update scale-set-agents.md

### DIFF
--- a/docs/pipelines/agents/scale-set-agents.md
+++ b/docs/pipelines/agents/scale-set-agents.md
@@ -247,8 +247,8 @@ az vmss extension set \
 --resource-group <resource group> \
 --name CustomScript \
 --version 2.0 \
---publisher Microsoft.Azure.Extensions
---settings '{ \"FileUris\":[\"https://<myGitHubRepoUrl>/myScript.sh\"], \"commandToExecute\": \"bash /myScript.sh /myArgs \" }'
+--publisher Microsoft.Azure.Extensions \
+--settings '{ \"fileUris\":[\"https://<myGitHubRepoUrl>/myScript.sh\"], \"commandToExecute\": \"bash ./myScript.sh /myArgs \" }'
 ```
 
 Here is an example to create a custom script extension for Windows.


### PR DESCRIPTION
three typo's in the custom script extension for Linux section

missed backslash after --publisher
missed dot before /myScript.sh
fileUris is camel-case, (F was caps)