### PR TITLE
Fix Portable PDB documentation in symbols.md

### DIFF
--- a/docs/pipelines/artifacts/symbols.md
+++ b/docs/pipelines/artifacts/symbols.md
@@ -56,7 +56,7 @@ Add the task to your build pipeline and configure it as follows:
 
 ## Portable PDBs
 
-If you're using [portable PDBs](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md), you still need to use the **Index Sources and Publish Symbols** task to publish symbols. For portable PDBs, the build does the indexing, however you should [use SourceLink](/dotnet/standard/library-guidance/sourcelink) to index the symbols as part of the build. Note that Azure Artifacts doesn't presently support ingesting NuGet symbol packages and so the task is used to publish the generated PDB files into the symbols service directly.
+If you're using [portable PDBs](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md), you still need to use the **Index Sources and Publish Symbols** task to publish symbols. For portable PDBs, the build does the indexing, however you should [use Source Link](/dotnet/standard/library-guidance/sourcelink) to index the symbols as part of the build. Note that Azure Artifacts doesn't presently support ingesting NuGet symbol packages and so the task is used to publish the generated PDB files into the symbols service directly.
 
 ## Use indexed symbols to debug your app
 
@@ -122,7 +122,7 @@ A: Symbols have the same retention as the build. When you delete a build, you al
 
 #### Q: Can I use source indexing on a portable .pdb file created from a .NET Core assembly?
 
-A: No, source indexing is currently not enabled for portable .pdb files because SourceLink doesn't support authenticated source repositories. The workaround at the moment is to configure the build to generate full .pdb files.
+A: No, source indexing is not supported for portable .pdb files. [Source Link](/dotnet/standard/library-guidance/sourcelink) should be used instead.
 
 #### Q: Is this available in TFS?
 


### PR DESCRIPTION
The documentation listed an incorrect reason for why source indexing isn't supported for portable PDBs. This removes this. 'Source Link' is also two words, so I fixed that as well.