### PR TITLE
Fixing capitalization in TOC

### DIFF
--- a/docs/project/wiki/toc.yml
+++ b/docs/project/wiki/toc.yml
@@ -1,4 +1,4 @@
-- name: "About wikis, READMes, & Markdown"
+- name: "About wikis, READMEs, & Markdown"
   href: about-readme-wiki.md  
 - name: Provisioned versus published wikis 
   href: provisioned-vs-published-wiki.md


### PR DESCRIPTION
The capitalization of the README doc did not match the name of the file itself.