### PR TITLE
Remove note that was potentially added by accident

### DIFF
--- a/docs/project/wiki/provisioned-vs-published-wiki.md
+++ b/docs/project/wiki/provisioned-vs-published-wiki.md
@@ -47,9 +47,6 @@ The unavailable menu options for the wiki pages are shown in the following illus
 
 For example, the **Edit in Repos** option for the publish code as wiki takes you to the **Repo** page to edit that specific page. Updates you make to a page in the branch you selected for the wiki get automatically published to the wiki.
 
-> [!NOTE]
-> Information the user should notice even if skimming
-
 ## Supported features and operational differences
 
 *Provisioned wikis* and *publish as code wikis* support the following features:


### PR DESCRIPTION
Hi,

It looks from the content of the note (see the diff for the related note) that it might have been added by accident in a recent update.

The note can be viewed live in the following article: https://docs.microsoft.com/en-us/azure/devops/project/wiki/provisioned-vs-published-wiki?view=azure-devops

Best regards