### PR TITLE
Fixed the definitionId of the run retention examples

### DIFF
--- a/docs/pipelines/build/run-retention.md
+++ b/docs/pipelines/build/run-retention.md
@@ -61,7 +61,7 @@ This is similar to above, only the condition needs to change:
     script: |
       $contentType = "application/json";
       $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };
-      $rawRequest = @{ daysValid = 365 * 2; definitionId = 1; ownerId = 'User:$(Build.RequestedForId)'; protectPipeline = $false; runId = $(Build.BuildId) };
+      $rawRequest = @{ daysValid = 365 * 2; definitionId = $(System.DefinitionId); ownerId = 'User:$(Build.RequestedForId)'; protectPipeline = $false; runId = $(Build.BuildId) };
       $request = ConvertTo-Json @($rawRequest);
       $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/retention/leases?api-version=6.0-preview.1";
       Invoke-RestMethod -uri $uri -method POST -Headers $headers -ContentType $contentType -Body $request;
@@ -84,7 +84,7 @@ The `Build` stage can retain the pipeline as in the above examples, but with one
   script: |
     $contentType = "application/json";
     $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };
-    $rawRequest = @{ daysValid = 3; definitionId = 1; ownerId = 'User:$(Build.RequestedForId)'; protectPipeline = $false; runId = $(Build.BuildId) };
+    $rawRequest = @{ daysValid = 3; definitionId = $(System.DefinitionId); ownerId = 'User:$(Build.RequestedForId)'; protectPipeline = $false; runId = $(Build.BuildId) };
     $request = ConvertTo-Json @($rawRequest);
     $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/retention/leases?api-version=6.0-preview.1";
     $newLease = Invoke-RestMethod -uri $uri -method POST -Headers $headers -ContentType $contentType -Body $request;


### PR DESCRIPTION
Previously, the example scripts were setting the `definitionId` attribute of the `NewRetentionLease` object to `1` instead of using the predefined variable, which resulted in the request failing with the following response:
```json
{
	"$id": "1",
	"innerException": null,
	"message": "Build pipeline 1 was not found.",
	"typeName": "Microsoft.TeamFoundation.Build.WebApi.DefinitionNotFoundException, Microsoft.TeamFoundation.Build2.WebApi",
	"typeKey": "DefinitionNotFoundException",
	"errorCode": 0,
	"eventId": 3000
}
```
Switching this value to `$(System.DefinitionId)` will instead dynamically fill in the attribute with the definition ID of the running pipeline.