### PR TITLE
Remove empty menu item

### DIFF
--- a/docs/boards/toc.yml
+++ b/docs/boards/toc.yml
@@ -136,8 +136,6 @@
     href: ../organizations/settings/work/object-limits.md?toc=/azure/devops/boards/toc.json&bc=/azure/devops/boards/breadcrumb/toc.json 
     displayName: customize, migrate, import
   - name: Configure & customize
-    items:
-  - name: Configure & customize
     href: configure-customize.md
     displayname: Scrum, Kanban, Scrumban, portfolio, hierarchy, rollup, calendar, time
   - name: Define area paths & assign to a team 


### PR DESCRIPTION
Currently is linking back to top level docs.microsoft.com which doesn't make sense