### PR TITLE
Adding an additional option for preserving VC tags and labels

### DIFF
--- a/docs/pipelines/policies/retention.md
+++ b/docs/pipelines/policies/retention.md
@@ -145,6 +145,7 @@ The following information is deleted when a run is deleted:
 * Binaries
 * Test results
 * Run metadata
+* Source labels (TFVC) or tags (Git)
 
 Universal packages, NuGet, npm, and other packages are not tied to pipelines retention. 
 
@@ -494,12 +495,13 @@ No. Manual test results are not deleted.
 
 ::: moniker range=">= azure-devops-2019"
 
-### How do I preserve my version control labels? 
+### How do I preserve my version control labels or tags? 
 
-Any version control labels that are applied during a build pipeline that arent automatically created from the Sources task will be preserved. However...
-# Version control labels automatically created from the builtin sources task during a build will be deleted when your build is deleted. 
+> [!CAUTION]
+> Any version control labels or tags that are applied during a build pipeline that arent automatically created from the Sources task will be preserved, even if the build is deleted. 
+> However, any version control labels or tags that are automatically created from the Sources task during a build are considered part of the build artifacts and will be deleted when the build is deleted. 
 
-If you need to preserve version control labels, you'll need to either tag or label it manually (or via an additional task/script in the pipeline) or manually retain any associated builds.
+If version control labels or tags need to be preserved, even when the build is deleted, they will need to be either applied as part of a task in the pipeline, manually labeled outside of the pipeline, or the build will need to be retained indefinitely.
 
 ::: moniker-end
 

--- a/docs/pipelines/policies/retention.md
+++ b/docs/pipelines/policies/retention.md
@@ -496,7 +496,10 @@ No. Manual test results are not deleted.
 
 ### How do I preserve my version control labels? 
 
-Version control labels created during a build will be deleted when your build is deleted. If you need to preserve version control labels, you'll need to retain any associated builds. 
+Any version control labels that are applied during a build pipeline that arent automatically created from the Sources task will be preserved. However...
+# Version control labels automatically created from the builtin sources task during a build will be deleted when your build is deleted. 
+
+If you need to preserve version control labels, you'll need to either tag or label it manually (or via an additional task/script in the pipeline) or manually retain any associated builds.
 
 ::: moniker-end
 


### PR DESCRIPTION
ref https://github.com/MicrosoftDocs/azure-devops-docs/issues/8692  

The H1/# in the middle is the only way I could figure out for displaying a "gotcha". It needs that kind of emphasis, but another attention getting convention is OK