### PR TITLE
Changed default value for branchName in Download Build Artifacts task

### DIFF
--- a/docs/pipelines/tasks/utility/download-build-artifacts.md
+++ b/docs/pipelines/tasks/utility/download-build-artifacts.md
@@ -34,7 +34,7 @@ Use this task to download build artifacts.
 |`specificBuildWithTriggering`<br/>When appropriate, download artifacts from the triggering build|(Optional) If true, this build task will try to download artifacts from the triggering build. If there is no triggering build from the specified pipeline, it will download artifacts from the build specified in the options below. <br/>Default value: `false`|
 |`buildVersionToDownload`<br/>Build version to download|(Required) Specify which version of the build to download.<br/><ul><li> Choose **`latest`** to download the latest available build version</li><li>Choose **`latestFromBranch`** to download the latest available build version of the branch specified by **`branchName`** and tags specified by **`tags`**</li><li>Choose **`specific`** to download the build version specified by buildId</li><ul/>|
 |`allowPartiallySucceededBuilds`<br/>Download artifacts even from partially succeeded builds|(Optional) If checked, this build task will try to download artifacts whether the build is succeeded or partially succeeded <br/>Default value: `false`|
-|`branchName`<br/>Branch name|(Required) Specify to filter on branch/ref name. <br/>Default value: `refs/heads/develop`|
+|`branchName`<br/>Branch name|(Required) Specify to filter on branch/ref name. <br/>Default value: `refs/heads/master`|
 |`buildId`<br/>Build|(Required) The build from which to download the artifacts|
 |`tags`<br/>Build tags|(Optional) A comma-delimited list of tags. Only builds with these tags will be returned.|
 |`downloadType`<br/>Download type|(Required) Choose whether to download a single artifact or all artifacts of a specific build. <br/>Default value: `single`|


### PR DESCRIPTION
The value in the description was invalid. The one presented in the snippet and in the code of the task is `master`.