### PR TITLE
Fix link to .artifactignore reference

### DIFF
--- a/docs/pipelines/artifacts/pipeline-artifacts.md
+++ b/docs/pipelines/artifacts/pipeline-artifacts.md
@@ -86,7 +86,7 @@ Things to keep in mind:
 
 ### Use .artifactignore
 
-`.artifactignore` uses the identical file-globbing syntax of `.gitignore` (with very few limitations) to provide a version-controlled way to specify which files should not be included when publishing artifacts. For more information, see [Use the .artifactignore file](../../artifacts/reference/artifactignore.md).
+`.artifactignore` uses the identical file-globbing syntax of `.gitignore` (with very few limitations) to provide a version-controlled way to specify which files should not be included when publishing artifacts. See [Use the .artifactignore file](../../artifacts/reference/artifactignore.md) for more details.
 
 Example: ignore all files except **.exe** files:
 

--- a/docs/pipelines/artifacts/pipeline-artifacts.md
+++ b/docs/pipelines/artifacts/pipeline-artifacts.md
@@ -86,7 +86,7 @@ Things to keep in mind:
 
 ### Use .artifactignore
 
-`.artifactignore` uses the identical file-globbing syntax of `.gitignore` (with very few limitations) to provide a version-controlled way to specify which files should not be included when publishing artifacts. For more information, see [.artifactIgnore usage].
+`.artifactignore` uses the identical file-globbing syntax of `.gitignore` (with very few limitations) to provide a version-controlled way to specify which files should not be included when publishing artifacts. For more information, see [Use the .artifactignore file](../../artifacts/reference/artifactignore.md).
 
 Example: ignore all files except **.exe** files:
 


### PR DESCRIPTION
At least, I assume https://github.com/MicrosoftDocs/azure-devops-docs/blob/98084ec9b654185e19004f691d03f7d5fc5394b2/docs/artifacts/reference/artifactignore.md is the article in question.