### PR TITLE
Add 'enabled: true' flag to schema of container resource trigger.

### DIFF
--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -514,8 +514,6 @@ resources:
         include: 
         - production* 
 ```
-The pipeline will trigger on all images whose tag matches `'production*'`, e.g. `production1`, `production-v1`, and `production-xyz`.
-
 ---
 #### Container resource variables
 Once you define a container as resource, container image metadata is passed to the pipeline in the form of variables. Information like image, registry, and connection details are made accessible across all the jobs to be used in your container deploy tasks. 

--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -498,7 +498,6 @@ resources:          # types: pipelines | repositories | containers | builds | pa
         exclude: [ string ]  # image tags on discard the trigger events, optional; defaults to none
 ```
 > Remark that the syntax of enabling container triggers for all image tags, i.e. using `'enabled: true'`, differs from that of other resource triggers. Pay close attention to the correct syntax for a particular resource.
-
 ## [Example](#tab/example)
 
 ```yaml
@@ -518,7 +517,6 @@ resources:
 The pipeline will trigger on all images whose tag match `'production*'`, e.g. `production1`, `production-v1`, and `production-xyz`.
 
 ---
-
 #### Container resource variables
 Once you define a container as resource, container image metadata is passed to the pipeline in the form of variables. Information like image, registry, and connection details are made accessible across all the jobs to be used in your container deploy tasks. 
 

--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -497,7 +497,11 @@ resources:          # types: pipelines | repositories | containers | builds | pa
         include: [ string ]  # image tags to consider the trigger events, optional; defaults to any new tag
         exclude: [ string ]  # image tags on discard the trigger events, optional; defaults to none
 ```
-> Remark that the syntax of enabling container triggers for all image tags, i.e. using `'enabled: true'`, differs from that of other resource triggers. Pay close attention to the correct syntax for a particular resource.
+
+> [!NOTE]
+> The syntax that's used to enable container triggers for all image tags (that is, `enabled: 'true'`) is different from the syntax that's used for other resource triggers. Pay close attention to using the correct syntax for a specific resource.
+
+
 ## [Example](#tab/example)
 
 ```yaml

--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -492,10 +492,13 @@ resources:          # types: pipelines | repositories | containers | builds | pa
     registry: string # registry for container images
     repository: string # name of the container image repository in ACR
     trigger: # Triggers are not enabled by default and need to be set explicitly
+      enabled: boolean # set to 'true' to trigger on all image tags if 'tags' is unset.
       tags:
         include: [ string ]  # image tags to consider the trigger events, optional; defaults to any new tag
         exclude: [ string ]  # image tags on discard the trigger events, optional; defaults to none
 ```
+> Remark that the syntax of enabling container triggers for all image tags, i.e. using `'enabled: true'`, differs from that of other resource triggers. Pay close attention to the correct syntax for a particular resource.
+
 ## [Example](#tab/example)
 
 ```yaml
@@ -512,7 +515,10 @@ resources:
         include: 
         - production* 
 ```
+The pipeline will trigger on all images whose tag match `'production*'`, e.g. `production1`, `production-v1`, and `production-xyz`.
+
 ---
+
 #### Container resource variables
 Once you define a container as resource, container image metadata is passed to the pipeline in the form of variables. Information like image, registry, and connection details are made accessible across all the jobs to be used in your container deploy tasks. 
 

--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -514,7 +514,7 @@ resources:
         include: 
         - production* 
 ```
-The pipeline will trigger on all images whose tag match `'production*'`, e.g. `production1`, `production-v1`, and `production-xyz`.
+The pipeline will trigger on all images whose tag matches `'production*'`, e.g. `production1`, `production-v1`, and `production-xyz`.
 
 ---
 #### Container resource variables


### PR DESCRIPTION
Add 'enabled: true' flag to schema of container resource trigger.

### Context
Me, and [at least one other person](https://stackoverflow.com/questions/66673609/creating-an-event-that-triggers-the-pipeline-when-a-acr-is-updated-with-new-imag) are attempting to use the syntax 
```
containers:
    - container: container
      type: ACR
      azureSubscription: ARM_endpoint
      resourceGroup: resourceGroup
      registry: registry
      repository: repository
      trigger: true # <---- problem
```
to specify that a pipeline should trigger on all images pushed to an ACR repository. This currently does not trigger the pipeline.

What works is 
```
containers:
    - container: container
      type: ACR
      azureSubscription: ARM_endpoint
      resourceGroup: resourceGroup
      registry: registry
      repository: repository
      trigger:
        enabled: true
```

I suspect that others people may chance upon the same mistake as [it was proposed as a solution back in 2019](https://developercommunity.visualstudio.com/t/acr-trigger-declared-in-yaml-not-created/833224).

