### PR TITLE
Added "Learn more" link for Demands Section

### DIFF
--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -1751,6 +1751,8 @@ pool:
 
 ---
 
+Learn more about [demands](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/demands?view=azure-devops&tabs=yaml)
+
 ::: moniker range=">=azure-devops-2020"
 
 ## Environment


### PR DESCRIPTION
The section for "Demands" did not have a link to learn more about it, so I included that.