### PR TITLE
Clarified how the build variables Build.SourcesDirectory and Build.Repository.LocalPath work (fixed partly wrong documentation)

### DIFF
--- a/docs/pipelines/build/includes/variables-hosted.md
+++ b/docs/pipelines/build/includes/variables-hosted.md
@@ -281,11 +281,11 @@ This variable is agent-scoped, and can be used as an environment variable in a s
 
 The local path on the agent where your source code files are downloaded. For example: <code>c:\agent_work\1\s</code><br><br>By default, new build pipelines update only the changed files. You can modify how files are downloaded on the <a href="/azure/devops/pipelines/repos/index" data-raw-source="[Repository tab](../repos/index.md)">Repository tab</a>.
 
-Important note: if you only check out one Git repository, this path will be the exact path to the code.
-If you check out multiple repositories, the behaviour is as follows (and might differ from the value of the Build.SourcesDirectory variable):
+Important note: If you check out only one Git repository, this path will be the exact path to the code.
+If you check out multiple repositories, the behavior is as follows (and might differ from the value of the Build.SourcesDirectory variable):
 <ul>
-<li>If the checkout step for the self (primary) repository has no custom checkout path defined, or the checkout path is the multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> for the self repository, then the value of this variable will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code></li>
-<li>If the checkout step for the self (primary) repository does have a custom checkout path defined (and it's not its multi-checkout default path) then this variable will contain the exact path to the self repository</li>
+<li>If the checkout step for the self (primary) repository has no custom checkout path defined, or the checkout path is the multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> for the self repository, the value of this variable will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>.</li>
+<li>If the checkout step for the self (primary) repository does have a custom checkout path defined (and it's not its multi-checkout default path), this variable will contain the exact path to the self repository.</li>
 </ul>
 This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
 </td>
@@ -409,7 +409,7 @@ Note: In TFVC, if you are running a gated check-in build or manually building a 
 
 The local path on the agent where your source code files are downloaded. For example: <code>c:\agent_work\1\s</code><br><br>By default, new build pipelines update only the changed files. 
 
-Important note: if you only check out one Git repository, this path will be the exact path to the code. If you check out multiple repositories, it will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>, even if the self (primary) repository is checked out to a custom path different from its multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> (in this respect the variable differes from the behaviour of the Build.Repository.LocalPath variable).
+Important note: If you check out only one Git repository, this path will be the exact path to the code. If you check out multiple repositories, it will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>, even if the self (primary) repository is checked out to a custom path different from its multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> (in this respect, the variable differes from the behavior of the Build.Repository.LocalPath variable).
 <br><br>
 This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
 </td>

--- a/docs/pipelines/build/includes/variables-hosted.md
+++ b/docs/pipelines/build/includes/variables-hosted.md
@@ -279,11 +279,15 @@ This variable is agent-scoped, and can be used as an environment variable in a s
 <td>
 
 
-The local path on the agent where your source code files are downloaded. For example: <code>c:\agent_work\1\s</code><br><br>By default, new build pipelines update only the changed files. You can modify how files are downloaded on the <a href="/azure/devops/pipelines/repos/index" data-raw-source="[Repository tab](../repos/index.md)">Repository tab</a>. Important note: if you only check out one Git repository, this path will be the exact path to the code. If you check out multiple repositories, it will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>.
-<br><br>
-This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
+The local path on the agent where your source code files are downloaded. For example: <code>c:\agent_work\1\s</code><br><br>By default, new build pipelines update only the changed files. You can modify how files are downloaded on the <a href="/azure/devops/pipelines/repos/index" data-raw-source="[Repository tab](../repos/index.md)">Repository tab</a>.
 
-<p>This variable is synonymous with Build.SourcesDirectory.</p>
+Important note: if you only check out one Git repository, this path will be the exact path to the code.
+If you check out multiple repositories, the behaviour is as follows (and might differ from the value of the Build.SourcesDirectory variable):
+<ul>
+<li>If the checkout step for the self (primary) repository has no custom checkout path defined, or the checkout path is the multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> for the self repository, then the value of this variable will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code></li>
+<li>If the checkout step for the self (primary) repository does have a custom checkout path defined (and it's not its multi-checkout default path) then this variable will contain the exact path to the self repository</li>
+</ul>
+This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
 </td>
 <td>No</td>
 </tr>
@@ -405,11 +409,9 @@ Note: In TFVC, if you are running a gated check-in build or manually building a 
 
 The local path on the agent where your source code files are downloaded. For example: <code>c:\agent_work\1\s</code><br><br>By default, new build pipelines update only the changed files. 
 
-Important note: if you only check out one Git repository, this path will be the exact path to the code. If you check out multiple repositories, it will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>.
+Important note: if you only check out one Git repository, this path will be the exact path to the code. If you check out multiple repositories, it will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>, even if the self (primary) repository is checked out to a custom path different from its multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> (in this respect the variable differes from the behaviour of the Build.Repository.LocalPath variable).
 <br><br>
 This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
-
-<p>This variable is synonymous with Build.Repository.LocalPath.</p>
 </td>
 <td>No</td>
 </tr>

--- a/docs/pipelines/build/includes/variables-server-2020.md
+++ b/docs/pipelines/build/includes/variables-server-2020.md
@@ -263,11 +263,11 @@ This variable is agent-scoped, and can be used as an environment variable in a s
 
 The local path on the agent where your source code files are downloaded. For example: <code>c:\agent_work\1\s</code><br><br>By default, new build pipelines update only the changed files. You can modify how files are downloaded on the <a href="/azure/devops/pipelines/repos/index" data-raw-source="[Repository tab](../repos/index.md)">Repository tab</a>.
 
-Important note: if you only check out one Git repository, this path will be the exact path to the code.
-If you check out multiple repositories, the behaviour is as follows (and might differ from the value of the Build.SourcesDirectory variable):
+Important note: If you check out only one Git repository, this path will be the exact path to the code.
+If you check out multiple repositories, the behavior is as follows (and might differ from the value of the Build.SourcesDirectory variable):
 <ul>
-<li>If the checkout step for the self (primary) repository has no custom checkout path defined, or the checkout path is the multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> for the self repository, then the value of this variable will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code></li>
-<li>If the checkout step for the self (primary) repository does have a custom checkout path defined (and it's not its multi-checkout default path) then this variable will contain the exact path to the self repository</li>
+<li>If the checkout step for the self (primary) repository has no custom checkout path defined, or the checkout path is the multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> for the self repository, the value of this variable will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>.</li>
+<li>If the checkout step for the self (primary) repository does have a custom checkout path defined (and it's not its multi-checkout default path), this variable will contain the exact path to the self repository.</li>
 </ul>
 This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
 </td>
@@ -391,7 +391,7 @@ Note: In TFVC, if you are running a gated check-in build or manually building a 
 
 The local path on the agent where your source code files are downloaded. For example: <code>c:\agent_work\1\s</code><br><br>By default, new build pipelines update only the changed files. 
 
-Important note: if you only check out one Git repository, this path will be the exact path to the code. If you check out multiple repositories, it will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>, even if the self (primary) repository is checked out to a custom path different from its multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> (in this respect the variable differes from the behaviour of the Build.Repository.LocalPath variable).
+Important note: If you check out only one Git repository, this path will be the exact path to the code. If you check out multiple repositories, it will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>, even if the self (primary) repository is checked out to a custom path different from its multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> (in this respect, the variable differes from the behavior of the Build.Repository.LocalPath variable).
 <br><br>
 This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
 </td>

--- a/docs/pipelines/build/includes/variables-server-2020.md
+++ b/docs/pipelines/build/includes/variables-server-2020.md
@@ -261,11 +261,15 @@ This variable is agent-scoped, and can be used as an environment variable in a s
 <td>
 
 
-The local path on the agent where your source code files are downloaded. For example: <code>c:\agent_work\1\s</code><br><br>By default, new build pipelines update only the changed files. You can modify how files are downloaded on the <a href="/azure/devops/pipelines/repos/index" data-raw-source="[Repository tab](../repos/index.md)">Repository tab</a>. Important note: if you only check out one Git repository, this path will be the exact path to the code. If you check out multiple repositories, it will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>.
-<br><br>
-This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
+The local path on the agent where your source code files are downloaded. For example: <code>c:\agent_work\1\s</code><br><br>By default, new build pipelines update only the changed files. You can modify how files are downloaded on the <a href="/azure/devops/pipelines/repos/index" data-raw-source="[Repository tab](../repos/index.md)">Repository tab</a>.
 
-<p>This variable is synonymous with Build.SourcesDirectory.</p>
+Important note: if you only check out one Git repository, this path will be the exact path to the code.
+If you check out multiple repositories, the behaviour is as follows (and might differ from the value of the Build.SourcesDirectory variable):
+<ul>
+<li>If the checkout step for the self (primary) repository has no custom checkout path defined, or the checkout path is the multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> for the self repository, then the value of this variable will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code></li>
+<li>If the checkout step for the self (primary) repository does have a custom checkout path defined (and it's not its multi-checkout default path) then this variable will contain the exact path to the self repository</li>
+</ul>
+This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
 </td>
 <td>No</td>
 </tr>
@@ -385,11 +389,11 @@ Note: In TFVC, if you are running a gated check-in build or manually building a 
 <td>
 
 
-The local path on the agent where your source code files are downloaded. For example: <code>c:\agent_work\1\s</code><br><br>By default, new build pipelines update only the changed files. You can modify how files are downloaded on the <a href="/azure/devops/pipelines/repos/index" data-raw-source="[Repository tab](../repos/index.md)">Repository tab</a>. Important note: if you only check out one Git repository, this path will be the exact path to the code. If you check out multiple repositories, it will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>.
+The local path on the agent where your source code files are downloaded. For example: <code>c:\agent_work\1\s</code><br><br>By default, new build pipelines update only the changed files. 
+
+Important note: if you only check out one Git repository, this path will be the exact path to the code. If you check out multiple repositories, it will revert to its default value, which is <code>$(Pipeline.Workspace)/s</code>, even if the self (primary) repository is checked out to a custom path different from its multi-checkout default path <code>$(Pipeline.Workspace)/s/&lt;RepoName&gt;</code> (in this respect the variable differes from the behaviour of the Build.Repository.LocalPath variable).
 <br><br>
 This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
-
-<p>This variable is synonymous with Build.Repository.LocalPath.</p>
 </td>
 <td>No</td>
 </tr>


### PR DESCRIPTION
Clarified how the build variables Build.SourcesDirectory and Build.Repository.LocalPath work. They are not synonymous and behave differently in some scenarios. Especially the behaviour of Build.Repository.LocalPath is currently documented wrong (or at least not to the full extend).

Since multi-checkouts are not possible with Azure DevOps Server 2019 we don't need to change the documentation for anything prior to Azure DevOps 2020 or the Azure DevOps Services.