### PR TITLE
PublishCodeCoverageResults snippet fix

### DIFF
--- a/docs/pipelines/ecosystems/dotnet-core.md
+++ b/docs/pipelines/ecosystems/dotnet-core.md
@@ -524,7 +524,7 @@ To run tests and publish code coverage with Coverlet:
     displayName: 'Publish code coverage report'
     inputs:
       codeCoverageTool: 'Cobertura'
-      summaryFileLocation: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
+      summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
   ```
 
 # [.NET < 5](#tab/netearlierversions)
@@ -542,7 +542,7 @@ To run tests and publish code coverage with Coverlet:
     displayName: 'Publish code coverage report'
     inputs:
       codeCoverageTool: 'Cobertura'
-      summaryFileLocation: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
+      summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
   ```
 
 ---


### PR DESCRIPTION
Hi there!
I suggest updating the snippet since the previous version was pointing to a wrong directory resulting in the `PublishCodeCoverageResult` task being unable to find the `coverage.cobertura.xml` file. The previous task in the pipeline writes this file to the temp directory - at least this approached finally worked for me.