### PR TITLE
When the users are removed from organization

### DIFF
--- a/docs/organizations/accounts/delete-organization-users.md
+++ b/docs/organizations/accounts/delete-organization-users.md
@@ -16,7 +16,7 @@ monikerRange: '>= azure-devops-2019'
 
 [!INCLUDE [version-azure-devops-plus-azure-devops-server-2020](../../includes/version-azure-devops-plus-azure-devops-server-2020.md)]
 
-If users no longer require access to a team, project, or your organization, you can remove their access.The workitems which were assigned to them will not be affected.
+If users no longer require access to a team, project, or your organization, you can remove their access. Work items that are assigned to the users aren't affected by removing user access.
 
 ## Prerequisites  
 

--- a/docs/organizations/accounts/delete-organization-users.md
+++ b/docs/organizations/accounts/delete-organization-users.md
@@ -16,7 +16,7 @@ monikerRange: '>= azure-devops-2019'
 
 [!INCLUDE [version-azure-devops-plus-azure-devops-server-2020](../../includes/version-azure-devops-plus-azure-devops-server-2020.md)]
 
-If users no longer require access to a team, project, or your organization, you can remove their access.
+If users no longer require access to a team, project, or your organization, you can remove their access.The workitems which were assigned to them will not be affected.
 
 ## Prerequisites  
 


### PR DESCRIPTION
My customer wants to know if the users are removed from the organization, will the work items assigned to the users be affected.
Based on my test, the work items will not be removed, and the settings in them will not be changed as well. Could you kindly update something about this issue in the document?