### PR TITLE
vsblob.visualstudio.net -> vsblob.visualstudio.com

### DIFF
--- a/docs/pipelines/agents/includes/v2/qa-firewall.md
+++ b/docs/pipelines/agents/includes/v2/qa-firewall.md
@@ -20,7 +20,7 @@ https://{organization_name}.visualstudio.com
 https://{organization_name}.vsrm.visualstudio.com
 https://{organization_name}.vstmr.visualstudio.com
 https://{organization_name}.pkgs.visualstudio.com
-https://{organization_name}.vsblob.visualstudio.net
+https://{organization_name}.vsblob.visualstudio.com
 https://{organization_name}.vssps.visualstudio.com
 ```
 
@@ -32,7 +32,7 @@ https://*.dev.azure.com
 https://login.microsoftonline.com
 https://management.core.windows.net
 https://vstsagentpackage.azureedge.net
-https://*.vsblob.visualstudio.net
+https://*.vsblob.visualstudio.com
 https://*.vssps.visualstudio.com
 ```
 


### PR DESCRIPTION
One of my customers encountered the issue due to the wrong URL. Based on the following Issues, the document should be corrected as soon as possible to prevent the other users from encountering the same issue.
https://github.com/MicrosoftDocs/azure-devops-docs/issues/10645
https://github.com/MicrosoftDocs/azure-devops-docs/issues/10941