### PR TITLE
Updating max parallel job jobs for Microsoft Hosted Agents

### DIFF
--- a/docs/pipelines/licensing/concurrent-jobs.md
+++ b/docs/pipelines/licensing/concurrent-jobs.md
@@ -22,7 +22,7 @@ A TFS _parallel job_ gives you the ability to run a single release at a time in 
 
 One free parallel job is included with every collection in a Team Foundation Server. Every Visual Studio Enterprise subscriber in a Team Foundation Server contributes one additional parallel job. 
 
-You can buy additional private jobs from the Visual Studio Marketplace.
+You can buy additional private jobs from the Visual Studio Marketplace. There is a maximum limit of 25 parallel jobs for Microsoft Hosted agents.
 
 ::: moniker-end
 


### PR DESCRIPTION
There is no information regarding the maximum parallel jobs available for Microsoft hosted agents. Updating this to reflect the 25 max.