### PR TITLE
Clarified limitation between VMSS and DevOps

### DIFF
--- a/docs/pipelines/agents/scale-set-agents.md
+++ b/docs/pipelines/agents/scale-set-agents.md
@@ -38,6 +38,8 @@ If you like self-hosted agents but wish that you could simplify managing them, y
 > - You cannot run Mac agents using scale sets. You can only run Windows or Linux agents this way.
 > 
 > - Using VMSS agent pools for Azure DevOps Services is only supported for Azure Public (global service) cloud. Currently, VMSS agent pools does not support any other [national cloud offerings](/azure/active-directory/develop/authentication-national-cloud). 
+>
+> - You should not associate a VMSS to multiple pools.
 
 
 ## Create the scale set


### PR DESCRIPTION
A VMSS should be associated to a single Azure DevOps pool.
Associating the same VMSS to multiple Azure DevOPs pool is not resulting in any error, but the VMSS will have strange behavior because it may receive concurrent/antagonic requests from Azure DevOps