### PR TITLE
Update Portable PDB section in index sources task

### DIFF
--- a/docs/pipelines/tasks/build/index-sources-publish-symbols.md
+++ b/docs/pipelines/tasks/build/index-sources-publish-symbols.md
@@ -168,7 +168,7 @@ tf.exe git view /collection:http://SERVER:8080/tfs/DefaultCollection /teamprojec
 
 ### Can I use source indexing on a portable PDB created from a .NET Core assembly?
 
-No, source indexing is currently not enabled for Portable PDBs as SourceLink doesn't support authenticated source repositories. The workaround at the moment is to configure the build to generate full PDBs. Note that if you are generating a .NET Standard 2.0 assembly and are generating full PDBs and consuming them in a .NET Framework (full CLR) application then you will be able to fetch sources from Azure Repos (provided you have embedded SourceLink information and enabled it in your IDE).
+No, [Source Link](/dotnet/standard/library-guidance/sourcelink) is the equivalent to source indexing for portable PDBs.
 
 ### Where can I learn more about symbol stores and debugging?
 


### PR DESCRIPTION
The documentation listed an incorrect reason for why source indexing isn't supported for portable PDBs. This updates the documentation.