### PR TITLE
Fix mermaid.js availability in wiki

### DIFF
--- a/docs/project/wiki/wiki-markdown-guidance.md
+++ b/docs/project/wiki/wiki-markdown-guidance.md
@@ -47,7 +47,7 @@ Consistency is maintained in the formatting in TOC.
 
 ::: moniker-end
 
-::: moniker range=">= azure-devops-2020"
+::: moniker range="azure-devops"
 
 ## Add Mermaid diagrams to a Wiki page
 
@@ -71,8 +71,6 @@ There's also a toolbar button to add a default Mermaid diagram to a wiki page.
 
 > [!NOTE]
 > Most HTML tags and fontawesome aren't supported in the Mermaid diagram syntax. Mermaid isn't supported in the Internet Explorer browser.
-> 
-> This feature is supported only in Azure DevOps Services (not in Azure DevOps Server).
 
 ::: moniker-end
 


### PR DESCRIPTION
Fixing #11289.

I changed the moniker range on the corresponding section. I was not able to make monikers work locally, but I checked similar uses of this monicker in some other files, so it should work. If someone has a resource I can read up on making monikers work locally, I'd appreciate it.

I removed the note indicating that mermaid.js in the markdown is only available for the devops services, as it is redundant if the section is never shown if the a server version is selected.