### PR TITLE
Update teams/iteration/area limits

### DIFF
--- a/docs/organizations/settings/work/object-limits.md
+++ b/docs/organizations/settings/work/object-limits.md
@@ -69,11 +69,11 @@ When working with teams, work item tags, backlogs, and boards, the following ope
 | Backlogs | 1,000 work items | 
 | Boards | 1,000 cards (excluding those cards in the [*Proposed* and *Completed* workflow state categories](../../../boards/work-items/workflow-and-state-categories.md)) | 
 | Taskboard | 1,000 tasks  | 
-| Teams | 5,000 per project | 
+| Teams | 5,000 per organization | 
 | Work item tags | 150,000 tag definitions per organization or collection | 
-| Area Paths | 10,000 per project
+| Area Paths | 10,000 per organization
 | Area Path Depth | 14
-| Iteration Paths | 10,000 per project
+| Iteration Paths | 10,000 per organization
 | Iteration Path Depth | 14
 
 Each backlog can display up to 10,000 work items. This is a limit on what the backlog can display, not a limit on the number of work items you can define. If your backlog exceeds this limit, then you may want to consider adding a team and moving some of the work items to the other team's backlog.


### PR DESCRIPTION
The team, iteration path, and area path limits are actually per-organization. This was revealed during the investigation for DTS Task 1851541.