### PR TITLE
Update `azureSubscription` description

### DIFF
--- a/docs/pipelines/tasks/deploy/azure-cli.md
+++ b/docs/pipelines/tasks/deploy/azure-cli.md
@@ -66,7 +66,7 @@ cross-platform agents running on Linux, macOS, or Windows operating systems.
 </tr>
 <tr>
     <td><code>scriptLocation</code><br/>Script Location</td>
-    <td>(Required) select <code>scriptPath</code> to use a script file or <code>inlineScript</code> if you want to write your script inline <br/>Default value: scriptPath</td>
+    <td>(Required) Select <code>scriptPath</code> to use a script file or <code>inlineScript</code> if you want to write your script inline <br/>Default value: scriptPath</td>
 </tr>
 <tr>
     <td><code>scriptPath</code><br/>Script Path</td>

--- a/docs/pipelines/tasks/deploy/azure-cli.md
+++ b/docs/pipelines/tasks/deploy/azure-cli.md
@@ -47,7 +47,7 @@ cross-platform agents running on Linux, macOS, or Windows operating systems.
   </thead>
 <tr>
     <td><code>azureSubscription</code><br/>Azure subscription</td>
-    <td>(Required) Select an Azure Resource Manager subscription for the deployment. This parameter is shown only when the selected task version is 0.* as Azure CLI task v1.0 supports only Azure Resource Manager (ARM) subscriptions</td>
+    <td>(Required) Name of an Azure Resource Manager service connection for authentication.</td>
 </tr>
 <tr>
     <td><code>scriptType</code><br/>Script Type</td>


### PR DESCRIPTION
Fix https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/azure-cli?view=azure-devops

> Select an Azure Resource Manager subscription for the deployment.

The current description of `azureSubscription` means a **subscription**. This contradicts the example on the very same page (https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/azure-cli?view=azure-devops#example), which says "azureSubscription: <Name of the Azure Resource Manager **service connection**>":

![image](https://user-images.githubusercontent.com/4003950/133040500-4ae3852d-b021-49ea-b9f0-b634c1418aea.png)

> This parameter is shown only when the selected task version is 0.* as Azure CLI task v1.0 supports only Azure Resource Manager (ARM) subscriptions

- This parameter is "specified", not "shown". 
- This sentence is confusing and logically impossible to understand.
- There is no document for 0.* and v1.0 anymore.

This PR changes the description of `azureSubscription` to make it in sync with `azureSubscription` in Azure PowerShell task (https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/azure-powershell?view=azure-devops#arguments).