### PR TITLE
Update qa2-1.md

### DIFF
--- a/docs/pipelines/repos/includes/qa2-1.md
+++ b/docs/pipelines/repos/includes/qa2-1.md
@@ -19,6 +19,4 @@ ms.date: 07/28/2020
 
 * Have you excluded the branches or paths to which you pushed your changes? Test by pushing a change to an included path in an included branch. Note that paths in triggers are case-sensitive. Make sure that you use the same case as those of real folders when specifying the paths in triggers.
 
-* Do you have wildcards in your path filters? Understand the limitations of wildcards in your paths as described in this article.
-
 * Did you just push a new branch? If so, the new branch may not start a new run. See the section "Behavior of triggers when new branches are created".


### PR DESCRIPTION
Update tips about wildcard use cases according to latest release notes regarding wildcards in trigger paths: docs.microsoft.com/en-us/azure/devops/release-notes/2021/sprint-192-update#support-for-wild-cards-in-path-filters