### PR TITLE
Add vssps.dev.azure.com using the dev.azure.com

### DIFF
--- a/docs/pipelines/agents/includes/v2/web-proxy-bypass.md
+++ b/docs/pipelines/agents/includes/v2/web-proxy-bypass.md
@@ -31,6 +31,7 @@ https://*.dev.azure.com
 https://login.microsoftonline.com
 https://management.core.windows.net
 https://vstsagentpackage.azureedge.net
+https://vssps.dev.azure.com
 ```
 
 To ensure your organization works with any existing firewall or IP restrictions, ensure that `dev.azure.com` and `*dev.azure.com` are open and update your allow-listed IPs to include the following IP addresses, based on your IP version. If you're currently allow-listing the `13.107.6.183` and `13.107.9.183` IP addresses, leave them in place, as you don't need to remove them.


### PR DESCRIPTION
Hi.

While building an azure devops agent,
A proxy allowed address was missing and a pull request was created.
