### PR TITLE
Update jenkins-queue-job.md

### DIFF
--- a/docs/pipelines/tasks/build/jenkins-queue-job.md
+++ b/docs/pipelines/tasks/build/jenkins-queue-job.md
@@ -125,7 +125,7 @@ None
    </tr>
 </table>
 
-## Team Foundation Server Plug-in
+## Team Foundation Server Plug-in 
 
 You can use Team Foundation Server Plug-in (version 5.2.0 or newer) to automatically collect files from the Jenkins workspace and download them into the build.
 


### PR DESCRIPTION
The steps in the document will not work because of the dependency on the Team Foundation Server Plug-in which is now deprecated per : https://issues.jenkins.io/browse/INFRA-2751