### PR TITLE
SSH with OpenSSL > 8.6 - where RSA is deprecated

### DIFF
--- a/docs/repos/git/use-ssh-keys-to-authenticate.md
+++ b/docs/repos/git/use-ssh-keys-to-authenticate.md
@@ -327,6 +327,14 @@ Host vs-ssh.visualstudio.com
   IdentityFile ~/.ssh/your_private_key
   IdentitiesOnly yes
 
+# OpenSSL 8.7 has DEPRECATED RSA. IF using OpenSSL version > 8.6 you will need to 
+# add the 'HostkeyAlgorithms' and 'PubkeyAcceptedAlgorithms' entries below. You can 
+# check the version of OpenSSL/OpenSSH you're using by running the command 'ssh -v localhost'    
+Host ssh.dev.azure.com
+  IdentityFile ~/.ssh/id_rsa
+  HostkeyAlgorithms +ssh-rsa
+  PubkeyAcceptedAlgorithms +ssh-rsa   
+
 # Less common scenario: if you need different keys for different organizations,
 # you'll need to use host aliases to create separate Host sections.
 # This is because all hosted Azure DevOps URLs have the same hostname


### PR DESCRIPTION
OpenSSL has deprecated RSA see https://www.openssh.com/txt/release-8.7.  Without the `~/.ssh/config` changes is this PR, its not possible to use ssh authentication 

You can recreate issue with OpenSSL > 8.6 as follows 

config in `~/.ssh/config`
```
Host ssh.dev.azure.com
  IdentityFile ~/.ssh/id_rsa
  IdentitiesOnly yes
```

output
```
~ ❯❯❯ ssh -v -T git@ssh.dev.azure.com          

OpenSSH_8.8p1, OpenSSL 1.1.1l  24 Aug 2021
debug1: Reading configuration data /Users/mahmed/.ssh/config
debug1: /Users/mahmed/.ssh/config line 1: Applying options for *
debug1: /Users/mahmed/.ssh/config line 4: Applying options for ssh.dev.azure.com
debug1: Reading configuration data /usr/local/etc/ssh/ssh_config
debug1: Connecting to ssh.dev.azure.com [51.104.26.0] port 22.
debug1: Connection established.
debug1: identity file /Users/mahmed/.ssh/id_rsa type 0
debug1: identity file /Users/mahmed/.ssh/id_rsa-cert type -1
debug1: Local version string SSH-2.0-OpenSSH_8.8
debug1: Remote protocol version 2.0, remote software version SSHBlackbox.10
debug1: compat_banner: no match: SSHBlackbox.10
debug1: Authenticating to ssh.dev.azure.com:22 as 'git'
debug1: load_hostkeys: fopen /Users/mahmed/.ssh/known_hosts2: No such file or directory
debug1: load_hostkeys: fopen /usr/local/etc/ssh/ssh_known_hosts: No such file or directory
debug1: load_hostkeys: fopen /usr/local/etc/ssh/ssh_known_hosts2: No such file or directory
debug1: SSH2_MSG_KEXINIT sent
debug1: SSH2_MSG_KEXINIT received
debug1: kex: algorithm: diffie-hellman-group-exchange-sha256
debug1: kex: host key algorithm: (no match)
Unable to negotiate with 51.104.26.0 port 22: no matching host key type found. Their offer: ssh-rsa
```

config in `~/.ssh/config`
```
Host ssh.dev.azure.com
  IdentityFile ~/.ssh/id_rsa
  HostkeyAlgorithms +ssh-rsa
  PubkeyAcceptedAlgorithms +ssh-rsa
```

output 

```
bash-3.2$ ssh -v -T git@ssh.dev.azure.com
OpenSSH_8.8p1, OpenSSL 1.1.1l  24 Aug 2021
debug1: Reading configuration data /Users/mahmed/.ssh/config
debug1: /Users/mahmed/.ssh/config line 1: Applying options for *
debug1: /Users/mahmed/.ssh/config line 4: Applying options for ssh.dev.azure.com
debug1: Reading configuration data /usr/local/etc/ssh/ssh_config
debug1: Connecting to ssh.dev.azure.com [51.104.26.0] port 22.
debug1: Connection established.
debug1: identity file /Users/mahmed/.ssh/id_rsa type 0
debug1: identity file /Users/mahmed/.ssh/id_rsa-cert type -1
debug1: Local version string SSH-2.0-OpenSSH_8.8
debug1: Remote protocol version 2.0, remote software version SSHBlackbox.10
debug1: compat_banner: no match: SSHBlackbox.10
debug1: Authenticating to ssh.dev.azure.com:22 as 'git'
debug1: load_hostkeys: fopen /Users/mahmed/.ssh/known_hosts2: No such file or directory
debug1: load_hostkeys: fopen /usr/local/etc/ssh/ssh_known_hosts: No such file or directory
debug1: load_hostkeys: fopen /usr/local/etc/ssh/ssh_known_hosts2: No such file or directory
debug1: SSH2_MSG_KEXINIT sent
debug1: SSH2_MSG_KEXINIT received
debug1: kex: algorithm: diffie-hellman-group-exchange-sha256
debug1: kex: host key algorithm: ssh-rsa
debug1: kex: server->client cipher: aes128-ctr MAC: hmac-sha2-256 compression: none
debug1: kex: client->server cipher: aes128-ctr MAC: hmac-sha2-256 compression: none
debug1: SSH2_MSG_KEX_DH_GEX_REQUEST(2048<8192<8192) sent
debug1: expecting SSH2_MSG_KEX_DH_GEX_GROUP
debug1: SSH2_MSG_KEX_DH_GEX_GROUP received
debug1: SSH2_MSG_KEX_DH_GEX_INIT sent
debug1: expecting SSH2_MSG_KEX_DH_GEX_REPLY
debug1: SSH2_MSG_KEX_DH_GEX_REPLY received
debug1: Server host key: ssh-rsa SHA256:ohD8VZEXGWo6Ez8GSEJQ9WpafgLFsOfLOtGGQCQo6Og
debug1: load_hostkeys: fopen /Users/mahmed/.ssh/known_hosts2: No such file or directory
debug1: load_hostkeys: fopen /usr/local/etc/ssh/ssh_known_hosts: No such file or directory
debug1: load_hostkeys: fopen /usr/local/etc/ssh/ssh_known_hosts2: No such file or directory
debug1: Host 'ssh.dev.azure.com' is known and matches the RSA host key.
debug1: Found key in /Users/mahmed/.ssh/known_hosts:1
debug1: rekey out after 4294967296 blocks
debug1: SSH2_MSG_NEWKEYS sent
debug1: expecting SSH2_MSG_NEWKEYS
debug1: SSH2_MSG_NEWKEYS received
debug1: rekey in after 4294967296 blocks
debug1: Will attempt key: /Users/mahmed/.ssh/id_rsa RSA SHA256:gRrgisVk9m+y4rnDIttMQK0c8ad0y/1iguCfWgks/w0 explicit agent
debug1: SSH2_MSG_SERVICE_ACCEPT received
debug1: Authentications that can continue: password,publickey
debug1: Next authentication method: publickey
debug1: Offering public key: /Users/mahmed/.ssh/id_rsa RSA SHA256:gRrgisVk9m+y4rnDIttMQK0c8ad0y/1iguCfWgks/w0 explicit agent
debug1: Server accepts key: /Users/mahmed/.ssh/id_rsa RSA SHA256:gRrgisVk9m+y4rnDIttMQK0c8ad0y/1iguCfWgks/w0 explicit agent
Authenticated to ssh.dev.azure.com ([51.104.26.0]:22) using "publickey".
debug1: channel 0: new [client-session]
debug1: Entering interactive session.
debug1: pledge: filesystem full
remote: Shell access is not supported.
shell request failed on channel 0
bash-3.2$ 
```

thanks to @ljtill for solving this
