### PR TITLE
Fix receiving signals in start.sh

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -226,7 +226,7 @@ Next, create the Dockerfile.
       && rm -rf /var/lib/apt/lists/*
 
     ARG TARGETARCH=amd64
-    ARG AGENT_VERSION=2.185.1
+    ARG AGENT_VERSION=2.194.0
 
     WORKDIR /azp
     RUN if [ "$TARGETARCH" = "amd64" ]; then \
@@ -322,7 +322,9 @@ Next, create the Dockerfile.
 
     # To be aware of TERM and INT signals call run.sh
     # Running it with the --once flag at the end will shut down the agent after the build is executed
-    ./run.sh "$@"
+    ./run.sh "$@" &
+
+    wait $!
     ```
     > [!NOTE]
     >You must also use a container orchestration system, like Kubernetes or [Azure Container Instances](https://azure.microsoft.com/services/container-instances/), to start new copies of the container when the work completes.


### PR DESCRIPTION
The current start.sh script is prepared to receive and handle signals like TERM and do some cleanup work (such as removing the agent from the portal).
However it runs the run.sh as a foreground process so even if it receives the signals it has to wait for the run.sh (which is the agent itself) to finish. But it won't finish as the signal is not propagated to the child.
An easy fix is to run the run.sh as a background process and wait for it at the end. In this case the start.sh can receive the signals properly and do the cleanup job. It's been tested and works fine.

Also I've updated the agent version to latest in the Dockerfile.