### PR TITLE
git credential manager: update name/links

### DIFF
--- a/docs/organizations/security/toc.yml
+++ b/docs/organizations/security/toc.yml
@@ -144,7 +144,7 @@
   - name: Use SSH key authentication
     href: ../../repos/git/use-ssh-keys-to-authenticate.md?toc=/azure/devops/organizations/toc.json&bc=/azure/devops/organizations/breadcrumb/toc.json
     displayName: access, security
-  - name: Use Git Credential Manager Core 
+  - name: Use Git Credential Manager 
     href: ../../repos/git/set-up-credential-managers.md?toc=/azure/devops/organizations/toc.json&bc=/azure/devops/organizations/breadcrumb/toc.json
     displayName: authenticate, access, security
   - name: Revoke users' PATs (for admins)

--- a/docs/repos/git/auth-overview.md
+++ b/docs/repos/git/auth-overview.md
@@ -43,7 +43,7 @@ Use PATs to authenticate if you don't already have SSH keys set up on your syste
 
 ### <a name="use-credential-managers-to-generate-tokens"></a>Use Git Credential Manager to generate tokens
 
-The [Git Credential Manager Core](set-up-credential-managers.md) is an optional tool that makes it easy to create PATs when you're working with Azure Repos. 
+The [Git Credential Manager](set-up-credential-managers.md) is an optional tool that makes it easy to create PATs when you're working with Azure Repos. 
 Sign in to the web portal, generate a token, and then use the token as your password when you're connecting to Azure Repos. 
 
 PATs are generated on demand when you have the credential manager installed. 

--- a/docs/repos/git/command-prompt.md
+++ b/docs/repos/git/command-prompt.md
@@ -27,7 +27,7 @@ Team Explorer and the Git command-line work great together. When you make update
 [Git Installation instructions](/devops/develop/git/install-and-set-up-git) are available if you don't have Git installed on your computer.
 
 > [!TIP]
-> Windows users: If you aren't using Visual Studio, install [Git for Windows](https://git-scm.com/download/win) to set up the [Git Credential Manager Core](set-up-credential-managers.md). The credential manager makes it easy to authenticate with Azure Repos.
+> Windows users: If you aren't using Visual Studio, install [Git for Windows](https://git-scm.com/download/win) to set up the [Git Credential Manager](set-up-credential-managers.md). The credential manager makes it easy to authenticate with Azure Repos.
 
 While in Visual Studio, open a command prompt in your repo from Team Explorer's **Connect** view. Right-click your local repo and select **Open Command Prompt**
    

--- a/docs/repos/git/create-new-repo.md
+++ b/docs/repos/git/create-new-repo.md
@@ -20,7 +20,7 @@ Azure DevOps Services and TFS projects contain Git repositories, work items, bui
 * An organization in Azure DevOps. If you don't have one, you can [sign up](../../organizations/accounts/create-organization.md) for one for free. Each organization includes free, unlimited private Git repositories.
 * You must have the **Create repository** permission, which is granted by default to project administrators. For more information, see [Set Git repository permissions](set-git-repository-permissions.md).
 * Git command-line tools:
-  * [Install Git for Windows](https://git-scm.com/download/win), which includes [Git Credential Manager Core](set-up-credential-managers.md#windows)
+  * [Install Git for Windows](https://git-scm.com/download/win), which includes [Git Credential Manager](set-up-credential-managers.md#windows)
   * [Install Git for macOS and Linux](https://git-scm.com/downloads).
     * For macOS and Linux, we recommend [configuring SSH authentication](../git/use-ssh-keys-to-authenticate.md)
 

--- a/docs/repos/git/includes/personal-access-tokens.md
+++ b/docs/repos/git/includes/personal-access-tokens.md
@@ -152,7 +152,7 @@ git -c http.extraHeader="Authorization: Basic $B64Pat" clone https://dev.azure.c
 
 To keep your token more secure, use credential managers so you don't have to enter your credentials every time. We recommend the following credential manager:
 
-- [Git Credential Manager](https://github.com/microsoft/Git-Credential-Manager-Core) (Windows also requires [Git for Windows](https://www.git-scm.com/download/win))
+- [Git Credential Manager](https://github.com/GitCredentialManager/git-credential-manager) (Windows also requires [Git for Windows](https://www.git-scm.com/download/win))
 
 ### Use a PAT in your code
 

--- a/docs/repos/git/includes/personal-access-tokens.md
+++ b/docs/repos/git/includes/personal-access-tokens.md
@@ -152,7 +152,7 @@ git -c http.extraHeader="Authorization: Basic $B64Pat" clone https://dev.azure.c
 
 To keep your token more secure, use credential managers so you don't have to enter your credentials every time. We recommend the following credential manager:
 
-- [Git Credential Manager Core](https://github.com/microsoft/Git-Credential-Manager-Core) (Windows also requires [Git for Windows](https://www.git-scm.com/download/win))
+- [Git Credential Manager](https://github.com/microsoft/Git-Credential-Manager-Core) (Windows also requires [Git for Windows](https://www.git-scm.com/download/win))
 
 ### Use a PAT in your code
 

--- a/docs/repos/git/set-up-credential-managers.md
+++ b/docs/repos/git/set-up-credential-managers.md
@@ -38,7 +38,7 @@ You may [use SSH keys](use-ssh-keys-to-authenticate.md) to authenticate to Azure
 
 Installation instructions are included in the GitHub repository for GCM.
 On Mac, we recommend using [Homebrew](https://github.com/GitCredentialManager/git-credential-manager#macos-homebrew).
-On Linux, you can install from a [.deb](https://github.com/GitCredentialManager/git-credential-manager#linux-debian-package-deb) or a [tarball](https://github.com/GitCredentialManager/git-credential-manager#linux-tarball-targz).
+On Linux, you can install from a [.deb](https://github.com/GitCredentialManager/git-credential-manager#ubuntudebian-distributions) or a [tarball](https://github.com/GitCredentialManager/git-credential-manager#other-distributions).
 
 ## Using the Git Credential Manager
 

--- a/docs/repos/git/set-up-credential-managers.md
+++ b/docs/repos/git/set-up-credential-managers.md
@@ -34,11 +34,11 @@ Download and run the latest [Git for Windows installer](https://git-scm.com/down
 
 ### macOS and Linux
 
-You may [use SSH keys](use-ssh-keys-to-authenticate.md) to authenticate to Azure Repos, or you may use [Git Credential Manager](https://github.com/microsoft/Git-Credential-Manager-Core).
+You may [use SSH keys](use-ssh-keys-to-authenticate.md) to authenticate to Azure Repos, or you may use [Git Credential Manager](https://github.com/GitCredentialManager/git-credential-manager).
 
 Installation instructions are included in the GitHub repository for GCM.
-On Mac, we recommend using [Homebrew](https://github.com/microsoft/Git-Credential-Manager-Core#macos-homebrew).
-On Linux, you can install from a [.deb](https://github.com/microsoft/Git-Credential-Manager-Core#linux-debian-package-deb) or a [tarball](https://github.com/microsoft/Git-Credential-Manager-Core#linux-tarball-targz).
+On Mac, we recommend using [Homebrew](https://github.com/GitCredentialManager/git-credential-manager#macos-homebrew).
+On Linux, you can install from a [.deb](https://github.com/GitCredentialManager/git-credential-manager#linux-debian-package-deb) or a [tarball](https://github.com/GitCredentialManager/git-credential-manager#linux-tarball-targz).
 
 ## Using the Git Credential Manager
 

--- a/docs/repos/git/set-up-credential-managers.md
+++ b/docs/repos/git/set-up-credential-managers.md
@@ -9,12 +9,12 @@ ms.date: 11/13/2020
 monikerRange: '>= tfs-2015'
 ---
 
-# Use Git Credential Manager Core to authenticate to Azure Repos
+# Use Git Credential Manager to authenticate to Azure Repos
 
 [!INCLUDE [version-tfs-2015-cloud](../includes/version-tfs-2015-cloud.md)]
 [!INCLUDE [version-vs-2015-vs-2019](../includes/version-vs-2015-vs-2019.md)]
 
-Git Credential Manager Core simplifies authentication with your Azure Repos Git repositories. Credential managers let you use the same credentials that you use for the Azure DevOps Services web portal. Credential managers support multi-factor authentication through Microsoft account or Azure Active Directory (Azure AD).  Besides supporting multi-factor authentication with Azure Repos, credential managers also support [two-factor authentication](https://help.github.com/articles/about-two-factor-authentication/) with GitHub repositories.
+Git Credential Manager simplifies authentication with your Azure Repos Git repositories. Credential managers let you use the same credentials that you use for the Azure DevOps Services web portal. Credential managers support multi-factor authentication through Microsoft account or Azure Active Directory (Azure AD).  Besides supporting multi-factor authentication with Azure Repos, credential managers also support [two-factor authentication](https://help.github.com/articles/about-two-factor-authentication/) with GitHub repositories.
 
 Azure Repos provides IDE support for Microsoft account and Azure AD authentication through the following clients:
 
@@ -24,19 +24,19 @@ Azure Repos provides IDE support for Microsoft account and Azure AD authenticati
 
 If your environment doesn't have an integration available, configure your IDE with a [Personal Access Token](../../organizations/accounts/use-personal-access-tokens-to-authenticate.md) or [SSH](use-ssh-keys-to-authenticate.md) to connect to your repositories.
 
-## Install Git Credential Manager Core
+## Install Git Credential Manager
 
 ### Windows
 
-Download and run the latest [Git for Windows installer](https://git-scm.com/download/win), which includes Git Credential Manager Core. Make sure to enable the Git Credential Manager installation option.
+Download and run the latest [Git for Windows installer](https://git-scm.com/download/win), which includes Git Credential Manager. Make sure to enable the Git Credential Manager installation option.
 
    ![Select Enable Git Credential Manager during Git for Windows install](media/install-git-with-git-credential-manager.png) 
 
 ### macOS and Linux
 
-You may [use SSH keys](use-ssh-keys-to-authenticate.md) to authenticate to Azure Repos, or you may use [Git Credential Manager Core](https://github.com/microsoft/Git-Credential-Manager-Core).
+You may [use SSH keys](use-ssh-keys-to-authenticate.md) to authenticate to Azure Repos, or you may use [Git Credential Manager](https://github.com/microsoft/Git-Credential-Manager-Core).
 
-Installation instructions are included in the GitHub repository for GCM Core.
+Installation instructions are included in the GitHub repository for GCM.
 On Mac, we recommend using [Homebrew](https://github.com/microsoft/Git-Credential-Manager-Core#macos-homebrew).
 On Linux, you can install from a [.deb](https://github.com/microsoft/Git-Credential-Manager-Core#linux-debian-package-deb) or a [tarball](https://github.com/microsoft/Git-Credential-Manager-Core#linux-tarball-targz).
 
@@ -50,4 +50,4 @@ Once authenticated, the credential manager creates and caches a [personal access
 
 ### Getting help
 
-You can open and report issues with Git Credential Manager Core on the [project GitHub](https://github.com/microsoft/Git-Credential-Manager-Core/issues).
+You can open and report issues with Git Credential Manager on the [project GitHub](https://github.com/GitCredentialManager/Git-Credential-Manager/issues).

--- a/docs/repos/git/use-ssh-keys-to-authenticate.md
+++ b/docs/repos/git/use-ssh-keys-to-authenticate.md
@@ -13,7 +13,7 @@ monikerRange: '>= tfs-2015'
 
 [!INCLUDE [version-ts-tfs-2015-2016](../../includes/version-ts-tfs-2015-2016.md)]
 
-Connect to your Git repos through SSH on macOS, Linux, or Windows to securely connect using HTTPS authentication.  On Windows, we recommended the use of [Git Credential Manager Core](set-up-credential-managers.md) or [Personal Access Tokens](../../organizations/accounts/use-personal-access-tokens-to-authenticate.md).
+Connect to your Git repos through SSH on macOS, Linux, or Windows to securely connect using HTTPS authentication.  On Windows, we recommended the use of [Git Credential Manager](set-up-credential-managers.md) or [Personal Access Tokens](../../organizations/accounts/use-personal-access-tokens-to-authenticate.md).
 
 > [!IMPORTANT]
 > SSH URLs have changed, but old SSH URLs will continue to work. If you have already set up SSH, you should update your remote URLs to the new format:

--- a/docs/repos/tfvc/includes/personal-access-tokens.md
+++ b/docs/repos/tfvc/includes/personal-access-tokens.md
@@ -40,7 +40,7 @@ ms.topic: include
 
     Here are some recommended credential managers:
 
-    *	Git: [Git Credential Manager Core](https://github.com/microsoft/Git-Credential-Manager-Core) 
+    *	Git: [Git Credential Manager](https://github.com/microsoft/Git-Credential-Manager-Core) 
     *	NuGet: [NuGet Credential Provider](../../../artifacts/nuget/nuget-exe.md)
 
 7. When you don't need your token anymore, just revoke it to remove its access.

--- a/docs/repos/tfvc/includes/personal-access-tokens.md
+++ b/docs/repos/tfvc/includes/personal-access-tokens.md
@@ -40,7 +40,7 @@ ms.topic: include
 
     Here are some recommended credential managers:
 
-    *	Git: [Git Credential Manager](https://github.com/microsoft/Git-Credential-Manager-Core) 
+    *	Git: [Git Credential Manager](https://github.com/GitCredentialManager/git-credential-manager) 
     *	NuGet: [NuGet Credential Provider](../../../artifacts/nuget/nuget-exe.md)
 
 7. When you don't need your token anymore, just revoke it to remove its access.

--- a/release-notes/docswhatsnew/azure-devops-docs-2020-11.md
+++ b/release-notes/docswhatsnew/azure-devops-docs-2020-11.md
@@ -113,7 +113,7 @@ Welcome to what's new in the Azure DevOps docs from November 1, 2020 through Nov
 - [Forks](/azure/devops/repos/git/forks)
 - [Azure Repos Git Documentation](/azure/devops/repos/git/index)
 - [Move Git repositories to another project with full-fidelity history](/azure/devops/repos/git/move-git-repos-between-team-projects)
-- [Use Git Credential Manager Core to authenticate to Azure Repos](/azure/devops/repos/git/set-up-credential-managers)
+- [Use Git Credential Manager to authenticate to Azure Repos](/azure/devops/repos/git/set-up-credential-managers)
 - [Select an effective branching strategy](/azure/devops/repos/tfvc/branching-strategies-with-tfvc)
 
 ## Service-hooks


### PR DESCRIPTION
The Git Fundamentals team has changed the name of the Git Credential Manager Core tool to Git Credential Manager. The team has also migrated the repository into [its own org](https://github.com/GitCredentialManager). Updating the documentation in this repo to reflect these changes.