### PR TITLE
Update extract-files.md

### DIFF
--- a/docs/pipelines/tasks/utility/extract-files.md
+++ b/docs/pipelines/tasks/utility/extract-files.md
@@ -61,7 +61,7 @@ None
 </tr>
 <tr>
 <td>Overwrite files in the destination directory</td>
-<td>Select this option to overwrite files in the output directory if they already exist. If the option is false, the script prompts on existing files asking whether or not to overwrite them.</td>
+<td>Select this option to overwrite files in the output directory if they already exist. If the option is <code>false</code>, the script prompts on existing files, asking whether you want to overwrite them.</td>
 </tr>
 <tr>
 <td>Path to 7z utility</td>

--- a/docs/pipelines/tasks/utility/extract-files.md
+++ b/docs/pipelines/tasks/utility/extract-files.md
@@ -61,7 +61,7 @@ None
 </tr>
 <tr>
 <td>Overwrite files in the destination directory</td>
-<td>Select this option to overwrite files in the output directory if they already exist.</td>
+<td>Select this option to overwrite files in the output directory if they already exist. If the option is false script promts on existing files asking whether or not to override them.</td>
 </tr>
 <tr>
 <td>Path to 7z utility</td>

--- a/docs/pipelines/tasks/utility/extract-files.md
+++ b/docs/pipelines/tasks/utility/extract-files.md
@@ -61,7 +61,7 @@ None
 </tr>
 <tr>
 <td>Overwrite files in the destination directory</td>
-<td>Select this option to overwrite files in the output directory if they already exist. If the option is false script promts on existing files asking whether or not to override them.</td>
+<td>Select this option to overwrite files in the output directory if they already exist. If the option is false, the script prompts on existing files asking whether or not to overwrite them.</td>
 </tr>
 <tr>
 <td>Path to 7z utility</td>


### PR DESCRIPTION
Proposing an update for the description of the overwriteExistingFiles-option. The motivation behind the proposed change is to try to describe more explicitly how the overwriteExistingFiles option works in the case of existing files. One might assume that when the overwriteExistingFiles option is set to false no user interaction is needed when there is existing files in the output directory.