### PR TITLE
Remove pip instructions for Pipeline Caching

### DIFF
--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -437,52 +437,6 @@ steps:
 - script: yarn --frozen-lockfile
 ```
 
-## Python/pip
-
-For Python projects that use pip or Poetry, override the `PIP_CACHE_DIR` environment variable. If you use Poetry, in the `key` field, replace `requirements.txt` with `poetry.lock`.
-
-### Example
-
-```yaml
-variables:
-  PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-
-steps:
-- task: Cache@2
-  inputs:
-    key: 'python | "$(Agent.OS)" | requirements.txt'
-    restoreKeys: | 
-      python | "$(Agent.OS)"
-      python
-    path: $(PIP_CACHE_DIR)
-  displayName: Cache pip packages
-
-- script: pip install -r requirements.txt
-```
-
-## Python/Pipenv
-
-For Python projects that use Pipenv, override the `PIPENV_CACHE_DIR` environment variable.
-
-### Example
-
-```yaml
-variables:
-  PIPENV_CACHE_DIR: $(Pipeline.Workspace)/.pipenv
-
-steps:
-- task: Cache@2
-  inputs:
-    key: 'python | "$(Agent.OS)" | Pipfile.lock'
-    restoreKeys: | 
-      python | "$(Agent.OS)"
-      python
-    path: $(PIPENV_CACHE_DIR)
-  displayName: Cache pipenv packages
-
-- script: pipenv install
-```
-
 ## Python/Anaconda
 
 Set up your pipeline caching with Anaconda environments 


### PR DESCRIPTION
pip bases its caching on the redirected URL which includes the SAS key which constantly changes, so it effectively doesn't work.