### PR TITLE
Update set-variables-scripts.md

### DIFF
--- a/docs/pipelines/process/set-variables-scripts.md
+++ b/docs/pipelines/process/set-variables-scripts.md
@@ -285,6 +285,7 @@ stages:
      - bash: echo "##vso[task.setvariable variable=myStageVal;isOutput=true]this is a stage output variable"
        name: MyOutputVar
 - stage: B
+  dependsOn: A
   jobs:
   - job: B1
     variables:


### PR DESCRIPTION
I had trouble accessing variables across stages in my YAML pipeline when using the current code snippet as reference.

After my debugging I discovered that the code snippet in 'Set a variable for future stages' section is missing a `dependsOn` segment stating it's dependence on stage `A`. 

The variables cannot be accessed across the stages without the `dependsOn: A`  line.

My Pull Request adds this line to the code snippet in the documentation.