### PR TITLE
Moving the "Note" section higher in the page

### DIFF
--- a/docs/organizations/accounts/azure-ad-tenant-policy-restrict-org-creation.md
+++ b/docs/organizations/accounts/azure-ad-tenant-policy-restrict-org-creation.md
@@ -27,7 +27,7 @@ If you don't see the policy section in Azure DevOps, then you aren't an administ
 ![Check Azure AD roles and administrators](media/azure-ad-tenant-policy/azure-ad-roles-and-administrators.png)
 
 > [!NOTE]
-> An Azure DevOps Administrator can only restrict new organization creation for individual users, rather than groups at this time. 
+> Currently, an Azure DevOps Administrator can restrict new organization creation only for individual users, and not for groups. 
 
 You can also check your role using the Azure AD PowerShell module.
 ![Azure AD PowerShell to enable policy](media/azure-ad-tenant-policy/azure-ad-powershell.png)

--- a/docs/organizations/accounts/azure-ad-tenant-policy-restrict-org-creation.md
+++ b/docs/organizations/accounts/azure-ad-tenant-policy-restrict-org-creation.md
@@ -26,13 +26,13 @@ If you don't see the policy section in Azure DevOps, then you aren't an administ
 
 ![Check Azure AD roles and administrators](media/azure-ad-tenant-policy/azure-ad-roles-and-administrators.png)
 
+> [!NOTE]
+> An Azure DevOps Administrator can only restrict new organization creation for individual users, rather than groups at this time. 
+
 You can also check your role using the Azure AD PowerShell module.
 ![Azure AD PowerShell to enable policy](media/azure-ad-tenant-policy/azure-ad-powershell.png)
 
 For more information about the new built-in Azure AD roles, see [Administrator role permissions in Azure Active Directory](/azure/active-directory/users-groups-roles/directory-assign-admin-roles).
-
-> [!NOTE]
-> An Azure DevOps Administrator can only restrict new organization creation for individual users, rather than groups at this time. 
 
 ## Turn on the policy
 


### PR DESCRIPTION
The "Note" section that talks about the need for direct assignment of the role and groups wont work is present below in the page and sometimes users miss this part. So, moving it higher, so that users wont miss this critical piece of info.