### PR TITLE
Basic Authentication does not use PATs

### DIFF
--- a/docs/integrate/get-started/authentication/iis-basic-auth.md
+++ b/docs/integrate/get-started/authentication/iis-basic-auth.md
@@ -30,7 +30,7 @@ The extra header must include a base 64 encoding of "user:PAT". See the followin
 ### Format
 
    ```
-   git -c http.extraheader='Authorization: Basic [base 64 encoding of "user:PAT"]' ls-remote http://tfsserver:8080/tfs/DefaultCollection/_git/projectName
+   git -c http.extraheader='Authorization: Basic [base 64 encoding of "user:password"]' ls-remote http://tfsserver:8080/tfs/DefaultCollection/_git/projectName
    ```
 
 ### Example


### PR DESCRIPTION
As stated in the docs above IIS Basic Authentication breaks PAT Authentication. Therefore a user:PAT combination does not work and should be user:password as you are user Basic Authentication and not the "PAT Basic Auth".