### PR TITLE
Emphasise implications of Microsoft-hosted agents creating a new virtual machine for each job

### DIFF
--- a/docs/pipelines/agents/includes/hosted-agent-intro.md
+++ b/docs/pipelines/agents/includes/hosted-agent-intro.md
@@ -7,7 +7,7 @@ author: steved0x
 ms.date: 02/12/2020
 ---
 
-If your pipelines are in Azure Pipelines, then you've got a convenient option to run your jobs using a **Microsoft-hosted agent**. With Microsoft-hosted agents, maintenance and upgrades are taken care of for you. Each time you run a pipeline, you get a fresh virtual machine for each job in the pipeline. The virtual machine is discarded after one job (which means any change a job makes to the virtual machine file system such as checking out code will be unavailable to the next job). Microsoft-hosted agents can run jobs [directly on the VM](../../process/phases.md) or [in a container](../../process/container-phases.md).
+If your pipelines are in Azure Pipelines, then you've got a convenient option to run your jobs using a **Microsoft-hosted agent**. With Microsoft-hosted agents, maintenance and upgrades are taken care of for you. Each time you run a pipeline, you get a fresh virtual machine for each job in the pipeline. The virtual machine is discarded after one job (which means any change that a job makes to the virtual machine file system, such as checking out code, will be unavailable to the next job). Microsoft-hosted agents can run jobs [directly on the VM](../../process/phases.md) or [in a container](../../process/container-phases.md).
 
 Azure Pipelines provides a predefined agent pool named **Azure Pipelines** with Microsoft-hosted agents.
 

--- a/docs/pipelines/agents/includes/hosted-agent-intro.md
+++ b/docs/pipelines/agents/includes/hosted-agent-intro.md
@@ -7,7 +7,7 @@ author: steved0x
 ms.date: 02/12/2020
 ---
 
-If your pipelines are in Azure Pipelines, then you've got a convenient option to run your jobs using a **Microsoft-hosted agent**. With Microsoft-hosted agents, maintenance and upgrades are taken care of for you. Each time you run a pipeline, you get a fresh virtual machine for each job in the pipeline. The virtual machine is discarded after one job. Microsoft-hosted agents can run jobs [directly on the VM](../../process/phases.md) or [in a container](../../process/container-phases.md).
+If your pipelines are in Azure Pipelines, then you've got a convenient option to run your jobs using a **Microsoft-hosted agent**. With Microsoft-hosted agents, maintenance and upgrades are taken care of for you. Each time you run a pipeline, you get a fresh virtual machine for each job in the pipeline. The virtual machine is discarded after one job (which means any change a job makes to the virtual machine file system such as checking out code will be unavailable to the next job). Microsoft-hosted agents can run jobs [directly on the VM](../../process/phases.md) or [in a container](../../process/container-phases.md).
 
 Azure Pipelines provides a predefined agent pool named **Azure Pipelines** with Microsoft-hosted agents.
 


### PR DESCRIPTION
I think it is worth emphasising the implications of getting a new virtual machine for each job with Microsoft-hosted agents - if you're used to working with self-hosted agents, it is really quite a big difference in behaviour, and I read this page more than once before the implications had really sunk in. You can't do things like check out code in one job, and then expect it to be there in dependent jobs, for instance.