### PR TITLE
Rename job names in examples to avoid reserved words

### DIFF
--- a/docs/pipelines/ecosystems/kubernetes/aks-template.md
+++ b/docs/pipelines/ecosystems/kubernetes/aks-template.md
@@ -161,7 +161,7 @@ The deployment job uses the _Kubernetes manifest task_ to create the `imagePullS
   displayName: Deploy stage
   dependsOn: Build
   jobs:
-  - deployment: Deploy
+  - deployment: MyDeploy
     displayName: Deploy job
     pool:
       vmImage: $(vmImageName)

--- a/docs/pipelines/process/deployment-jobs.md
+++ b/docs/pipelines/process/deployment-jobs.md
@@ -131,7 +131,7 @@ If you are using self-hosted agents, you can use the workspace clean options to 
 
 ```yaml
   jobs:
-  - deployment: deploy
+  - deployment: MyDeploy
     pool:
       vmImage: 'ubuntu-latest'
       workspace:

--- a/docs/pipelines/process/environments-kubernetes.md
+++ b/docs/pipelines/process/environments-kubernetes.md
@@ -151,7 +151,7 @@ stages:
   dependsOn: Build
 
   jobs:
-  - deployment: Deploy
+  - deployment: MyDeploy
     condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
     displayName: Deploy
     pool:

--- a/docs/pipelines/process/phases.md
+++ b/docs/pipelines/process/phases.md
@@ -868,7 +868,7 @@ When you specify one of the `clean` options, they are interpreted as follows:
 
 ```yaml
   jobs:
-  - deployment: deploy
+  - deployment: MyDeploy
     pool:
       vmImage: 'ubuntu-latest'
     workspace:


### PR DESCRIPTION
According to the [YAML schema for deployment jobs](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/jobs-deployment?view=azure-pipelines#properties-2), the word `deploy` is a reserved word, that shouldn't be used as the name for a deployment job. However, a couple of examples throughout the documentation do use this word to name a deployment job.

In practice, this seems to be a problem only for deployment jobs that target Virtual Machine environments, and not for deployment jobs that target Kubernetes environments. It is, however, a cause of errors when you're trying to define a Virtual Machine deployment job using these Kubernetes examples.
