### PR TITLE
The user who creates Service Connection is added as "Administrator" on that Service Connection not added as "Administrator" at Project-level Service Connection Security.

### DIFF
--- a/docs/pipelines/library/service-endpoints.md
+++ b/docs/pipelines/library/service-endpoints.md
@@ -183,7 +183,7 @@ The project-level Administrator can do the following tasks:
 
 ![Azure Resource Manager project security](../release/_img/azure-rm-endpoint/azure-rm-project-level-security.png)
 
-The user who created the service connection is automatically added to the project-level Administrator role for that service connection. Users and groups assigned the Administrator role at the hub-level are inherited if the inheritance is turned on.
+The user who created the service connection is automatically added to the Administrator role for that service connection. Users and groups assigned the Administrator role at the hub-level are inherited if the inheritance is turned on.
 
 #### Organization-level permissions
 


### PR DESCRIPTION
Changed below line #176:

The user who created the service connection is automatically added to the project-level Administrator role for that service connection. Users and groups assigned the Administrator role at the hub-level are inherited if the inheritance is turned on.

To: below (without "project-level" as the user is only added as "Administrator" on the Service Connection he creates. He is not added as "Administrator" at the Project-level security:

The user who created the service connection is automatically added to the Administrator role for that service connection. Users and groups assigned the Administrator role at the hub-level are inherited if the inheritance is turned on.