### PR TITLE
Cache task is only available in ADO service

### DIFF
--- a/docs/pipelines/tasks/utility/cache.md
+++ b/docs/pipelines/tasks/utility/cache.md
@@ -11,7 +11,7 @@ monikerRange: '>= tfs-2017'
 
 # Cache task
 
-[!INCLUDE [version-gt-eq-2017](../../../includes/version-gt-eq-2017.md)]
+[!INCLUDE [version-eq-azure-devops](../../includes/version-eq-azure-devops.md)]
 
 Improve build performance by caching files, like dependencies, between pipeline runs.
 

--- a/docs/pipelines/tasks/utility/cache.md
+++ b/docs/pipelines/tasks/utility/cache.md
@@ -5,16 +5,16 @@ ms.topic: reference
 ms.assetid: 9D2AE683-E116-4CEA-B673-CD7BEFB8F415
 ms.custom: seodec18
 author: damccorm
-ms.date: 12/13/2019
-monikerRange: '>= tfs-2017'
+ms.date: 03/22/2022
+monikerRange: '= azure-devops'
 ---
 
 # Cache task
 
-**Azure DevOps Services | TFS 2018 - TFS 2017**
+**Azure DevOps Services**
 
 > [!NOTE]
-> This task is only available in Azure DevOps Services and TFS 2017 & 2018.
+> This task is only available in Azure DevOps Services.
 
 Improve build performance by caching files, like dependencies, between pipeline runs.
 
@@ -22,13 +22,9 @@ Improve build performance by caching files, like dependencies, between pipeline 
 
 None
 
-::: moniker range="> tfs-2018"
-
 ## YAML snippet
 
 [!INCLUDE [temp](../includes/yaml/cache-v2.md)]
-
-::: moniker-end
 
 ## Arguments
 

--- a/docs/pipelines/tasks/utility/cache.md
+++ b/docs/pipelines/tasks/utility/cache.md
@@ -11,7 +11,10 @@ monikerRange: '>= tfs-2017'
 
 # Cache task
 
-[!INCLUDE [version-eq-azure-devops](../../includes/version-eq-azure-devops.md)]
+**Azure DevOps Services | TFS 2018 - TFS 2017**
+
+> [!NOTE]
+> This task is only available in Azure DevOps Services and TFS 2017 & 2018.
 
 Improve build performance by caching files, like dependencies, between pipeline runs.
 


### PR DESCRIPTION
Update cache docs so that it is clear that the task is only available in the service, not on-prem product.