### PR TITLE
Update of NuGet Push examples

### DIFF
--- a/docs/pipelines/tasks/package/nuget.md
+++ b/docs/pipelines/tasks/package/nuget.md
@@ -166,7 +166,7 @@ Create a NuGet package in the destination folder.
         nugetConfigPath: '$(Build.WorkingDirectory)/NuGet.config'
     ```
 
-* Push/Publish a package to a organization scoped feed
+* Push/Publish a package to an organization scoped feed
 
     ```YAML
     # Push a project

--- a/docs/pipelines/tasks/package/nuget.md
+++ b/docs/pipelines/tasks/package/nuget.md
@@ -152,7 +152,7 @@ Create a NuGet package in the destination folder.
 ### Push
 
 > [!NOTE]
-> Pipeline artifacts are downloaded to `System.ArtifactsDirectory` directory. `packagesToPush` value can be set to `$(System.ArtifactsDirectory)/**/*.nupkg` in your release pipeline.
+> Pipeline artifacts are downloaded to the `Pipeline.Workspace` directory, and to the `System.ArtifactsDirectory` directory for classic release pipelines. `packagesToPush` value can be set to `$(Pipeline.Workspace)/**/*.nupkg` or `$(System.ArtifactsDirectory)/**/*.nupkg` respectively.
 
 * Push/Publish a package to a feed defined in your NuGet.config.
 
@@ -166,16 +166,26 @@ Create a NuGet package in the destination folder.
         nugetConfigPath: '$(Build.WorkingDirectory)/NuGet.config'
     ```
 
-* Push/Publish a package to a project scoped
+* Push/Publish a package to a organization scoped feed
 
     ```YAML
     # Push a project
     - task: NuGetCommand@2
       inputs:
         command: 'push'
-        feedsToUse: 'select'
-        vstsFeed: 'my-project/my-project-scoped-feed'
-        publishVstsFeed: 'myTestFeed'
+        nuGetFeedType: 'internal'
+        publishVstsFeed: 'my-organization-scoped-feed'
+    ```
+    
+* Push/Publish a package to a project scoped feed
+
+    ```YAML
+    # Push a project
+    - task: NuGetCommand@2
+      inputs:
+        command: 'push'
+        nuGetFeedType: 'internal'
+        publishVstsFeed: 'my-project/my-project-scoped-feed'
     ```
 
 * Push/Publish a package to NuGet.org


### PR DESCRIPTION
The existing NuGet Push example for a project scoped feed was incorrect/did not work. It has been updated to include the correct and relevant parameters, along with adding an example for an organization scoped feed.

The existing note for the Pipeline Artifacts directory made me configure the wrong directory in my own pipeline, so I have attempted to add clarity to it.