### PR TITLE
Add back section on default .git exclusion

### DIFF
--- a/docs/artifacts/reference/artifactignore.md
+++ b/docs/artifacts/reference/artifactignore.md
@@ -38,6 +38,10 @@ The *.artifactignore* follows the same syntax as the [.gitignore](https://git-sc
 > [!IMPORTANT]
 > The plus sign character `+` is not supported in URL paths and some of the semantic versioning metadata for some package types like Maven.
 
+## Ignored by default
+
+To reduce the chances of publishing the *.git* folder, we automatically ignore this path if you do not have an *.artifactignore* file. You can re-include it by creating an empty *.artifactignore* file.
+
 ## Related articles
 
 - [Package graphs](../concepts/package-graph.md)


### PR DESCRIPTION
I've confirmed this through multiple tests.
Azure Artifacts will exclude the `.git` folder by default if you don't have an .artifactignore folder, so this section (removed in 395ab7aa45c1df2ddf9acffd77502a6e0199f84d) should be added back with a few modifications.

It should probably also appear in the ["Publish artifacts"](https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-artifacts) article, given that this behavior happens **without** an .artifactignore file, so people might not even think to look there.