### PR TITLE
Update kubernetes-manifest.md

### DIFF
--- a/docs/pipelines/tasks/deploy/kubernetes-manifest.md
+++ b/docs/pipelines/tasks/deploy/kubernetes-manifest.md
@@ -81,7 +81,7 @@ The following list shows the key benefits of this task:
     <td><b>manifests</b><br/>Manifests</td>
     <td>(Required)<br/>
     <br/>
-    The path to the manifest files to be used for deployment. Each line represents a single path. A <a href="../file-matching-patterns.md" data-raw-source="[file-matching pattern](../file-matching-patterns.md)"> file-matching pattern</a> is an acceptable value for each line. You can use [kubectl kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) to merge multiple YAML files into one. This can be useful when using this task in classic release pipelines.</td>
+    The path to the manifest files to be used for deployment. Each line represents a single path. A <a href="../file-matching-patterns.md" data-raw-source="[file-matching pattern](../file-matching-patterns.md)"> file-matching pattern</a> is an acceptable value for each line. You can use <a href="https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/" data-raw-source="[kubectl kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/)"> to merge multiple YAML files into one. This can be useful when using this task in classic release pipelines.</td>
   </tr>
   <tr>
     <td><b>containers</b><br/>Containers</td>

--- a/docs/pipelines/tasks/deploy/kubernetes-manifest.md
+++ b/docs/pipelines/tasks/deploy/kubernetes-manifest.md
@@ -81,7 +81,7 @@ The following list shows the key benefits of this task:
     <td><b>manifests</b><br/>Manifests</td>
     <td>(Required)<br/>
     <br/>
-    The path to the manifest files to be used for deployment. Each line represents a single path. A <a href="../file-matching-patterns.md" data-raw-source="[file-matching pattern](../file-matching-patterns.md)"> file-matching pattern</a> is an acceptable value for each line. (Note you can use <code>kubectl kustomize</code> to compile multiple manifest files into one, which is useful when using this task in Release pipelines.)</td>
+    The path to the manifest files to be used for deployment. Each line represents a single path. A <a href="../file-matching-patterns.md" data-raw-source="[file-matching pattern](../file-matching-patterns.md)"> file-matching pattern</a> is an acceptable value for each line. You can use [kubectl kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) to merge multiple YAML files into one. This can be useful when using this task in classic release pipelines.</td>
   </tr>
   <tr>
     <td><b>containers</b><br/>Containers</td>

--- a/docs/pipelines/tasks/deploy/kubernetes-manifest.md
+++ b/docs/pipelines/tasks/deploy/kubernetes-manifest.md
@@ -81,7 +81,7 @@ The following list shows the key benefits of this task:
     <td><b>manifests</b><br/>Manifests</td>
     <td>(Required)<br/>
     <br/>
-    The path to the manifest files to be used for deployment. Each line represents a single path. A <a href="../file-matching-patterns.md" data-raw-source="[file-matching pattern](../file-matching-patterns.md)"> file-matching pattern</a> is an acceptable value for each line.</td>
+    The path to the manifest files to be used for deployment. Each line represents a single path. A <a href="../file-matching-patterns.md" data-raw-source="[file-matching pattern](../file-matching-patterns.md)"> file-matching pattern</a> is an acceptable value for each line. (Note you can use <code>kubectl kustomize</code> to compile multiple manifest files into one, which is useful when using this task in Release pipelines.)</td>
   </tr>
   <tr>
     <td><b>containers</b><br/>Containers</td>


### PR DESCRIPTION
Add a note about using `kubectl kustomize` to combine multiple manifest files into one.

Problem:

Refer to https://github.com/microsoft/azure-pipelines-tasks/issues/16055

Basically, you can't specify multiple file paths when using this task in Release pipelines, so you need to use a tool to combine them into one, and `kubectl kustomize` is the perfect tool to achieve this. 