### PR TITLE
Update rest api versioning from query param to uri

### DIFF
--- a/docs/integrate/concepts/rest-api-versioning.md
+++ b/docs/integrate/concepts/rest-api-versioning.md
@@ -34,10 +34,12 @@ HTTP request header:
 Accept: application/json;api-version=1.0
 ```
 
-Query parameter:
+Uri:
 
 ```no-highlight
-GET https://dev.azure.com/{organization}/_apis/{area}/{resource}?api-version=1.0
+[scheme"://"][host[':'port]]"/v" major-version '/'namespace '/'resource ('/'resource)* '?' query
+We could delete the below, unless we want an example of something specific to azure dev ops...
+GET https://dev.azure.com/v1.0/{organization}/_apis/{area}/{resource}?some-query=1000
 ```
 
 ### Supported versions

--- a/docs/integrate/concepts/rest-api-versioning.md
+++ b/docs/integrate/concepts/rest-api-versioning.md
@@ -39,7 +39,7 @@ Uri:
 ```no-highlight
 [scheme"://"][host[':'port]]"/v" major-version '/'namespace '/'resource ('/'resource)* '?' query
 
-GET https://dev.azure.com/v1.0/{organization}/_apis/{area}/{resource}?some-query=1000
+i.e. GET https://dev.azure.com/v1.0/{organization}/_apis/{area}/{resource}?some-query=1000
 ```
 
 ### Supported versions

--- a/docs/integrate/concepts/rest-api-versioning.md
+++ b/docs/integrate/concepts/rest-api-versioning.md
@@ -38,7 +38,7 @@ Uri:
 
 ```no-highlight
 [scheme"://"][host[':'port]]"/v" major-version '/'namespace '/'resource ('/'resource)* '?' query
-We could delete the below, unless we want an example of something specific to azure dev ops...
+
 GET https://dev.azure.com/v1.0/{organization}/_apis/{area}/{resource}?some-query=1000
 ```
 


### PR DESCRIPTION
As per Rest api guidelines we should have api versioning in the path rather than the query parameter...
For more information please refer to the below:
 -  my open issue: https://github.com/MicrosoftDocs/azure-devops-docs/issues/12072
 -  rest guidelines:  https://gist.github.com/chrisidakwo/d5c10343cc406ebee33575e21a6a63ce
Fixes https://github.com/MicrosoftDocs/azure-devops-docs/issues/12072