### PR TITLE
Missing parent for job in user defined variables

### DIFF
--- a/docs/pipelines/process/variables.md
+++ b/docs/pipelines/process/variables.md
@@ -619,6 +619,7 @@ stages:
     - task: MyTask@1  # this step generates the output variable
       name: ProduceVar  # because we're going to depend on it, we need to name the step
 - stage: Two
+  jobs:
   - job: B
     variables:
       # map the output variable from A into this job


### PR DESCRIPTION
Missing parent for job in user defined variables documentation when describing how to pass a variable to another stage