### PR TITLE
git-log-history...: fix description typo

### DIFF
--- a/docs/repos/git/git-log-history-simplification.md
+++ b/docs/repos/git/git-log-history-simplification.md
@@ -1,6 +1,6 @@
 ---
 title: Understand Git history simplification
-description: Learn ho git log history simplification works
+description: Learn how git log history simplification works
 ms.topic: conceptual
 ms.technology: devops-code-git
 ms.assetid: 663ea04b-ee1e-41f9-8c5b-dfc269b093c2


### PR DESCRIPTION
Caught this in the preview window when I pasted this link into Slack.

I used the web editor, so I don't know why that last line is shown as changed.