### PR TITLE
Fixed yaml code snippet to clean workspace

### DIFF
--- a/docs/pipelines/process/deployment-jobs.md
+++ b/docs/pipelines/process/deployment-jobs.md
@@ -134,8 +134,8 @@ If you are using self-hosted agents, you can use the workspace clean options to 
   - deployment: deploy
     pool:
       vmImage: 'ubuntu-latest'
-      workspace:
-        clean: all
+    workspace:
+      clean: all
     environment: staging
 ```
 


### PR DESCRIPTION
Fixed the YAML code snippet that demonstrated the workspace clean options to clean the deployment workspace.
As per this [YAML Schema for pools](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pool?view=azure-pipelines), `workspace` is not valid inside the `pool`.