### PR TITLE
Update docker.md

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -129,7 +129,7 @@ Next, create the Dockerfile.
       Write-Host "3. Configuring Azure Pipelines agent..." -ForegroundColor Cyan
       
       .\config.cmd --unattended `
-        --agent "$(if (Test-Path Env:AZP_AGENT_NAME) { ${Env:AZP_AGENT_NAME} } else { ${Env:computername} })" `
+        --agent "$(if (Test-Path Env:AZP_AGENT_NAME) { ${Env:AZP_AGENT_NAME} } else { hostname })" `
         --url "$(${Env:AZP_URL})" `
         --auth PAT `
         --token "$(Get-Content ${Env:AZP_TOKEN_FILE})" `


### PR DESCRIPTION
For a Windows docker agent deployed on AKS, we get this error when we want to have more than one Windows docker agent (pod) :

Connecting to the server.
Error reported in diagnostic logs. Please examine the log for more details.
- C:\azp\agent\_diag\Agent_20220413-135945-utc.log
A session for this agent already exists.
2022-04-13 13:59:56Z: Agent connect error: The task agent AZDEVOPS-DEPLOY already has an active session for owner AZDEVOPS-DEPLOY.. Retrying until reconnected.
A session for this agent already exists.
A session for this agent already exists.
A session for this agent already exists.
A session for this agent already exists.
A session for this agent already exists.
A session for this agent already exists.
A session for this agent already exists.
Stop retry on SessionConflictException after retried for 240 seconds.
Failed to create session. The task agent AZDEVOPS-DEPLOY already has an active session for owner AZDEVOPS-DEPLOY.
Cleanup. Removing Azure Pipelines agent...
Removing agent from the server
Connecting to server ...
Succeeded: Removing agent from the server
Removing .credentials
Succeeded: Removing .credentials
Removing .agent
Succeeded: Removing .agent


To fix this issue, I change the parameter $env:computername to hostname as $env:computername is static and hostname is dynamic.