### PR TITLE
Update resolve-orphaned-organization.md

### DIFF
--- a/docs/organizations/accounts/resolve-orphaned-organization.md
+++ b/docs/organizations/accounts/resolve-orphaned-organization.md
@@ -25,7 +25,7 @@ For organizations connected to Azure AD, if the Owner and all other Project Coll
 
 ## Prerequisites
 
-- You must be an [Azure DevOps Administrator](/azure/active-directory/users-groups-roles/directory-assign-admin-roles#azure-devops-administrator) in Azure AD. It isn't a requirement to be a Project Collection Administrator.
+- You must be an [Azure DevOps Administrator](/azure/active-directory/users-groups-roles/directory-assign-admin-roles#azure-devops-administrator) in Azure AD. If you are using [Privileged Identity Management](https://docs.microsoft.com/en-us/azure/active-directory/privileged-identity-management/pim-configure?msclkid=303229fdc6c111ecaf0f666b2dd9cd6f) then the Azure DevOps Administrator must be of type [Active](https://docs.microsoft.com/en-us/azure/active-directory/privileged-identity-management/pim-how-to-add-role-to-user?msclkid=5cdc55f5c6c011eca737e344cbe17b42). It isn't a requirement to be a Project Collection Administrator.
 - The Azure DevOps Administrator role can only claim ownership of organizations when the current owner and all members of the Project Collection Administrators group are inactive in the backing Azure AD
 
 ### Find your Azure DevOps Administrator


### PR DESCRIPTION
Changed section Prerequisites. 
Adding that the type of the user if using Privileged Identity Management must be of type 'Active'.

Fixes https://github.com/MicrosoftDocs/azure-devops-docs/issues/12245