### PR TITLE
Improve convertToJson example

### DIFF
--- a/docs/pipelines/process/expressions.md
+++ b/docs/pipelines/process/expressions.md
@@ -210,17 +210,20 @@ parameters:
  
 steps:
 - script: |
-    json=$(echo '${{ convertToJson(parameters.listOfValues) }}')
+    echo "${MY_JSON}"
+  env:
+    MY_JSON: ${{ convertToJson(parameters.listOfValues) }}
 ```
 
+Script output:
+
 ```json
-# Example output
 {
-  this_is: {
-    a_complex: object,
-    with: [
-      one,
-      two
+  "this_is": {
+    "a_complex": "object",
+    "with": [
+      "one",
+      "two"
     ]
   }
 }


### PR DESCRIPTION
Using arbitrary text as part of the _source code_ of a program is
error-prone and unsecure, so this change replaces the implicit
suggestion to do so with a simpler, safer, more robust solution.

👉 https://github.com/MicrosoftDocs/azure-devops-docs/issues/11983#issuecomment-1125092780

`# Example output` is not valid JSON, so this change also removes it
from the `json` code block.

Resolves #11983.