### PR TITLE
Change example output_location to /build

### DIFF
--- a/docs/pipelines/tasks/utility/azure-static-web-app.md
+++ b/docs/pipelines/tasks/utility/azure-static-web-app.md
@@ -50,7 +50,7 @@ steps:
     inputs:
       app_location: '/src'
       api_location: 'api'
-      output_location: '/src'
+      output_location: '/build'
       azure_static_web_apps_api_token: $(deployment_token)
 ```
 


### PR DESCRIPTION
`output_location` of `/src` doesn't makes sense since it's where the source files are