### PR TITLE
Update namespace-reference.md

### DIFF
--- a/docs/organizations/security/namespace-reference.md
+++ b/docs/organizations/security/namespace-reference.md
@@ -948,7 +948,7 @@ The following table describes the security namespaces and permissions that aren'
    :::column span="2":::
       Manages permissions to view, manage, moderate, and contribute to [code review discussions setup for Azure Pipelines](../../pipelines/process/environments-kubernetes.md#set-up-review-app).  
       <br/>
-      **ID:** `0d140cae-8ac1-4f48-b6d1-c93ce0301a128`
+      **ID:** `0d140cae-8ac1-4f48-b6d1-c93ce0301a12`
    :::column-end:::
 :::row-end:::
 ---


### PR DESCRIPTION
Removed extra character added to namespace, which does not coincide with the output of https://dev.azure.com/{organization}/_apis/securitynamespaces.