### PR TITLE
Update personal-access-tokens.md

### DIFF
--- a/docs/repos/git/includes/personal-access-tokens.md
+++ b/docs/repos/git/includes/personal-access-tokens.md
@@ -146,7 +146,7 @@ In PowerShell, enter the following code.
 ```powershell
 $MyPat = ':PatStringFromWebUI'
 $UserName = ':UserNameToUseWithToken'
-$B64Pat = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$UserName:$MyPat"))
+$B64Pat = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("${$UserName}:$MyPat"))
 git -c http.extraHeader="Authorization: Basic $B64Pat" clone https://dev.azure.com/yourOrgName/yourProjectName/_git/yourRepoName
 ```
 


### PR DESCRIPTION
The Powershell command throws variable reference invalid error. Using ${} rectifies it.
Below image shows the error, when I copy the command and run the command "as is".

![image](https://user-images.githubusercontent.com/13200163/173344548-d4bb5e83-56ae-47b2-8666-afb7ebe0c7f7.png)

