### PR TITLE
Clarify nuget push to Azure scenario doc

### DIFF
--- a/docs/artifacts/nuget/publish.md
+++ b/docs/artifacts/nuget/publish.md
@@ -8,7 +8,7 @@ ms.date: 07/15/2021
 monikerRange: '<= azure-devops'
 ---
 
-# Publish a NuGet package using the command line
+# Publish a NuGet package using the nuget.exe push command (NuGet CLI)
 
 [!INCLUDE [version-lt-eq-azure-devops](../../includes/version-lt-eq-azure-devops.md)]
 


### PR DESCRIPTION
Currently it's very hard to notice what is difference between https://docs.microsoft.com/en-us/azure/devops/artifacts/nuget/publish?view=azure-devops and https://docs.microsoft.com/en-us/azure/devops/artifacts/nuget/dotnet-exe?view=azure-devops-2020
Because both of them are command line.

FYI: We have 2 different docs https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-push for "nuget push" and https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-push for "dotnet nuget push"