### PR TITLE
Add PAT couldn't be used as ApiKey

### DIFF
--- a/docs/organizations/accounts/use-personal-access-tokens-to-authenticate.md
+++ b/docs/organizations/accounts/use-personal-access-tokens-to-authenticate.md
@@ -57,4 +57,8 @@ A: Azure DevOps scans for PATs checked into public repositories on GitHub. When 
 
 There's a policy for managing leaked PATs! For more information, see [Revoke leaked PATs automatically](manage-pats-with-policies-for-administrators.md#revoke-leaked-pats-automatically).
 
+### Q: Can I use PAT for pushing nupkg packages with dotnet/nuget.exe as ApiKey?
+
+A: No. Azure Artifacts feeds do not accept a personal access token (PAT) specified by this command-line argument. When using a local development environment, you must have the [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) installed which provides authentication when pushing or downloading packages (see examples section). For Azure hosted builds that interfact with Azure Artifacts feeds, you must use the [NuGet Authenticate](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate) task for the authentication.
+
 ::: moniker-end


### PR DESCRIPTION
Related to:  https://github.com/NuGet/Home/issues/7792
Customers are trying to pass PAT as `apikey` in command line, but Azdo doesn't accept it, we need to explicit about it.
