### PR TITLE
Variables are not available by default to the entire stage

### DIFF
--- a/docs/pipelines/process/set-variables-scripts.md
+++ b/docs/pipelines/process/set-variables-scripts.md
@@ -20,7 +20,7 @@ You'll use the `task.setvariable` logging command to set variables in [PowerShel
 
 ## About `task.setvariable`
 
-When you add a variable with `task.setvariable`, the following tasks can use the variable using macro syntax `$(myVar)`. The variable will only be available to tasks in the same stage by default. If you add the parameter `isoutput`, the syntax to call your variable changes. See [Set an output variable for use in the same job](#set-an-output-variable-for-use-in-the-same-job).
+When you add a variable with `task.setvariable`, the following tasks can use the variable using macro syntax `$(myVar)`. The variable will only be available to tasks in the same job by default. If you add the parameter `isoutput`, the syntax to call your variable changes. See [Set an output variable for use in the same job](#set-an-output-variable-for-use-in-the-same-job).
 
 # [Bash](#tab/bash)
 


### PR DESCRIPTION
As mentioned further down in the document, variables are not by default available to other jobs in the current stage, so I think using the word 'stage' here is incorrect. Variables are available by default to other tasks in the current job, so 'job' seems like the correct term.