### PR TITLE
Remove "preview" from macOS-12 image

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -35,7 +35,7 @@ The **Azure Pipelines** agent pool offers several virtual machine images to choo
 | Ubuntu 22.04 Preview | *ubuntu-22.04* | `ubuntu-22.04` | [Link](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2204-Readme.md)
 | Ubuntu 20.04 | *ubuntu-20.04* | `ubuntu-latest` OR `ubuntu-20.04` | [Link](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md)
 | Ubuntu 18.04 | *ubuntu-18.04* | `ubuntu-18.04` | [Link](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-Readme.md) |
-| macOS 12 Monterey Preview | *macOS-12* | `macOS-12` | [Link](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md) |
+| macOS 12 Monterey | *macOS-12* | `macOS-12` | [Link](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md) |
 | macOS 11 Big Sur | *macOS-11* | `macOS-latest` OR `macOS-11` | [Link](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md) |
 | macOS X Catalina 10.15 | *macOS-10.15* | `macOS-10.15` | [Link](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md) |
 


### PR DESCRIPTION
macOS-12 is now generally available https://github.com/actions/virtual-environments/issues/5446#issuecomment-1156397849 and
https://github.blog/changelog/2022-06-13-github-actions-macos-12-for-github-hosted-runners-is-now-generally-available/