### PR TITLE
Typo "Visual Studio build"→"Visual Studio Build"

### DIFF
--- a/docs/pipelines/tasks/includes/yaml/VSBuildV1.md
+++ b/docs/pipelines/tasks/includes/yaml/VSBuildV1.md
@@ -8,7 +8,7 @@ ms.technology: devops-cicd-tasks
 ---
 
 ```YAML
-# Visual Studio build
+# Visual Studio Build
 # Build with MSBuild and set the Visual Studio version property
 - task: VSBuild@1
   inputs:


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/visual-studio-build?view=azure-devops
https://github.com/MicrosoftDocs/azure-devops-docs/blob/main/docs/pipelines/tasks/includes/yaml/VSBuildV1.md
#PingMSFTDocs