### PR TITLE
Correcting Apache Maven product name

### DIFF
--- a/docs/artifacts/get-started-maven.md
+++ b/docs/artifacts/get-started-maven.md
@@ -17,7 +17,7 @@ This quickstart will guide you through setting up your Maven project to connect 
 ### Prerequisites
 
 - An Azure DevOps organization. [Create an organization](../organizations/accounts/create-organization.md), if you don't have one already.
-- [Install Maven Apache](https://maven.apache.org/download.cgi).
+- [Install Apache Maven](https://maven.apache.org/download.cgi).
 - An Azure Artifacts feed. [Create a feed](./concepts/feeds.md#create-public-feeds.) if you don't have one already.
 
 ## Set up authentication


### PR DESCRIPTION
Correcting `Install Maven Apache` link text to `Install Apache Maven` to fix #12493