### PR TITLE
remove prerequisites

### DIFF
--- a/docs/pipelines/agents/pool-consumption-report.md
+++ b/docs/pipelines/agents/pool-consumption-report.md
@@ -12,6 +12,11 @@ monikerRange: 'azure-devops'
 
 The pool consumption report enables you to view jobs running in your agent pools graphed with agent pool job concurrency over a span of up to 30 days. You can use this information to help decide whether your jobs aren't running because of concurrency limits. If you have many jobs queued or running jobs at the concurrency or online agents limit, you may wish to [purchase additional parallel jobs](../licensing/concurrent-jobs.md) or provision more self-hosted agents.
 
+## Prerequisites
+
+> [!IMPORTANT]
+> You must be a member of the [Project Collection Administrators](../../organizations/security/permissions.md#collection-level-groups) group to view the pool consumption reports for agent pools in an organization, including project level reports in that organization.
+
 ## Pool consumption report
 
 The pool consumption report is part of the **Analytics** tab for an agent pool and contains the following charts, depending on the agent pool type.

--- a/docs/pipelines/agents/pool-consumption-report.md
+++ b/docs/pipelines/agents/pool-consumption-report.md
@@ -12,15 +12,6 @@ monikerRange: 'azure-devops'
 
 The pool consumption report enables you to view jobs running in your agent pools graphed with agent pool job concurrency over a span of up to 30 days. You can use this information to help decide whether your jobs aren't running because of concurrency limits. If you have many jobs queued or running jobs at the concurrency or online agents limit, you may wish to [purchase additional parallel jobs](../licensing/concurrent-jobs.md) or provision more self-hosted agents.
 
-## Prerequisites
-
-> [!IMPORTANT]
-> You must be a member of the [Project Collection Administrators](../../organizations/security/permissions.md#collection-level-groups) group to view the pool consumption reports for agent pools in an organization, including project level reports in that organization.
-
-**Historical graph for agent pools** is in preview. To enable or disable this preview feature, navigate to [Preview features](../../project/navigation/preview-features.md), find **Historical graph for agent pools**, and choose the desired setting.
-
-:::image type="content" source="media/pool-consumption-report/historical-graph-for-agent-pools-setting.png" alt-text="Historical graph for agent pools preview setting.":::
-
 ## Pool consumption report
 
 The pool consumption report is part of the **Analytics** tab for an agent pool and contains the following charts, depending on the agent pool type.


### PR DESCRIPTION
**Historical graph for agent pools** is not a preview feature anymore, so prerequisites section is not required