### PR TITLE
Add clarification

### DIFF
--- a/docs/pipelines/tasks/utility/bash.md
+++ b/docs/pipelines/tasks/utility/bash.md
@@ -55,7 +55,7 @@ steps:
     MYSECRET: $(Foo)
 ```
 
-The example above is equivalent to:
+On macOS or Linux, the example above is equivalent to:
 
 ```YAML
 steps:


### PR DESCRIPTION
On Windows, the `- script` shorthand would use `cmd.exe` and not bash