### PR TITLE
Update variables-hosted.md

### DIFF
--- a/docs/pipelines/build/includes/variables-hosted.md
+++ b/docs/pipelines/build/includes/variables-hosted.md
@@ -755,7 +755,7 @@ Otherwise, it is set to <code>False</code>.</td>
 <tr>
 <td>System.StageName</td>
 <td>A string-based identifier for a stage, typically used for expressing dependencies and accessing output variables.</td>
-<td>Yes</td>
+<td>No</td>
 </tr>
 
 


### PR DESCRIPTION
"System.StageName" was not available in the template.

For example, if you define the following, condition can be judged without any problem, but "variables ['System.StageName']" under inputs will be expanded with Null.
-------------------------------
steps:
- task: AzureCLI@2
  condition: and(succeeded(), eq(variables['System.StageName'], 'TestStage'))
  inputs:
    ${{ if eq(variables['System.StageName'], 'TestStage') }}:
      azureSubscription: 'Test1'
    ${{ else }}:
      azureSubscription: 'Test2'
    scriptType: 'ps'
    scriptLocation: 'inlineScript'
    inlineScript: 'Write-Host test'
-------------------------------

I downloaded the Pipeline log and checked initializeLog.txt.
I was able to confirm that it was expanded as Null as shown below.
-------------------------------
Template Parameters:
Begin evaluating template '/azure-pipelines-2.yml'
Evaluating: eq(variables['System.StageName'], 'TestStage')
Expanded: eq(Null, 'TestStage')
…
-------------------------------

Therefore, it is possible that "No" is correct for "Available in templates?".