### PR TITLE
Update caching.md

### DIFF
--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -277,7 +277,7 @@ steps:
 
   - script: |
       mkdir -p $(Pipeline.Workspace)/docker
-      docker save -o $(Pipeline.Workspace)/docker/cache.tar cache $(repository):$(tag)
+      docker save -o $(Pipeline.Workspace)/docker/cache.tar $(repository):$(tag)
     displayName: Docker save
     condition: and(not(canceled()), or(failed(), ne(variables.CACHE_RESTORED, 'true')))
 ```


### PR DESCRIPTION
- remove extra argument to docker save command (Usage:  docker save [OPTIONS] IMAGE [IMAGE...])

The ***Post-job: Pipeline -> Docker Cache*** takes care of the `cache.tar` saved too `$(Pipeline.Workspace)/docker/cache.tar` 