### PR TITLE
Explicitly mention the default condition includes both direct and indirect dependencies

### DIFF
--- a/docs/pipelines/process/includes/task-run-built-in-conditions.md
+++ b/docs/pipelines/process/includes/task-run-built-in-conditions.md
@@ -7,7 +7,7 @@ author: juliakm
 ms.date: 08/23/2021
 ---
 
-* Only when all previous dependencies with the same agent pool have succeeded. If you have different agent pools, those stages or jobs will run concurrently. This is the default if there is not a condition set in the YAML.
+* Only when all previous direct and indirect dependencies with the same agent pool have succeeded. If you have different agent pools, those stages or jobs will run concurrently. This is the default if there is not a condition set in the YAML.
 
 * Even if a previous dependency has failed, unless the run was canceled. Use `succeededOrFailed()` in the YAML for this condition. 
 


### PR DESCRIPTION
I was recently setting up a pipeline that had three sequential stages where the first one was optional. Something like

```yaml
- stage: A
  condition: eq('${{ parameters.doStageA}}', 'true')

- stage: B
  dependsOn: A
  condition: in(dependencies.A.result, 'Succeeded', 'Skipped')

- stage: C
  dependsOn: B
```

Based on my first reading of the edited line I expected C to run regardless of if A was skipped, since I interpreted "all previous dependencies" as all dependencies explicitly mentioned in the `dependsOn` parameter.  However, C did not run when A was skipped.

This PR explicitly mentions the default behavior includes both direct and indirect dependencies.