### PR TITLE
Update prepare-permissions.md

### DIFF
--- a/docs/pipelines/agents/includes/v2/prepare-permissions.md
+++ b/docs/pipelines/agents/includes/v2/prepare-permissions.md
@@ -62,6 +62,9 @@ Learn more about [how agents communicate](../../agents.md#communication).
 3. [Create a personal access token](../../../../organizations/accounts/use-personal-access-tokens-to-authenticate.md).
 
    ![Create a personal access token.](/azure/devops/repos/git/media/add-personal-access-token.png)
+   
+  <!--Please add an image here to choose the Organization for which the PAT is being created. Currently there is an active bug due to which only PAT for "All accessible Organizations" works. Here is the Bug: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1942506 -->
+    ![image](https://user-images.githubusercontent.com/45830002/187760366-285ea9df-754e-4856-a207-6c7a7733ffc2.png)
 
 ::: moniker-end
 


### PR DESCRIPTION
Please add an image to choose the Organization for which the PAT is being created for Azure DevOps Server versions.
Currently there is an active bug due to which only PAT for "All accessible Organizations" works. Here is the Bug: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1942506 

Customer mentioned that the documentation does not indicate to choose PAT for "All accessible Organizations".

Actually, PAT should work for the specific collection but due to the active bug, for now, the workaround is that customers have to create PAT for "All accessible Organizations".