### PR TITLE
Fix typo in AzureFileCopyV3.md example yml

### DIFF
--- a/docs/pipelines/tasks/includes/yaml/AzureFileCopyV3.md
+++ b/docs/pipelines/tasks/includes/yaml/AzureFileCopyV3.md
@@ -38,7 +38,7 @@ ms.technology: devops-cicd
 ```YAML
 # Example: Upload files from Pipeline staging directory to blob storage.
 - task: AzureFileCopy@2
-  displayName: 'Example Step Name
+  displayName: 'Example Step Name'
   inputs:
     sourcePath: '$(Build.ArtifactStagingDirectory)/BlobsToUpload'
     additionalArgumentsForBlobCopy: |


### PR DESCRIPTION
This will correct the syntax highlighting for the code block