### PR TITLE
docs(azure-repos-git): remove extra moniker-end

### DIFF
--- a/docs/pipelines/repos/azure-repos-git.md
+++ b/docs/pipelines/repos/azure-repos-git.md
@@ -74,7 +74,6 @@ Continuous integration (CI) triggers cause a pipeline to run whenever you push a
 [!INCLUDE [ci-triggers](includes/ci-triggers2.md)]
 
 [!INCLUDE [ci-triggers](includes/ci-triggers3.md)]
-::: moniker-end
 
 ::: moniker range="< azure-devops-2019"
 YAML pipelines aren't available in TFS.


### PR DESCRIPTION
The page at https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#disabling-the-ci-trigger shows an extra moniker-end tag.
This PR removes the tag.
I think that I removed the correct tag, but I couldn't verify it locally because I don't know how to run the docs site.

![image](https://user-images.githubusercontent.com/28659384/188707675-a695b933-f300-4fcc-87dd-35ce3dbb51c6.png)
