### PR TITLE
Mermaid is wikis: note about limited support is now more prominent

### DIFF
--- a/docs/project/wiki/wiki-markdown-guidance.md
+++ b/docs/project/wiki/wiki-markdown-guidance.md
@@ -50,7 +50,12 @@ Consistency is maintained in the formatting in TOC.
 
 ## Add Mermaid diagrams to a Wiki page
 
-Mermaid lets you create diagrams and visualizations using text and code. Wiki supports the following Mermaid diagram types:
+Mermaid lets you create diagrams and visualizations using text and code. 
+
+> [!NOTE]
+> Not all syntax in the content linked below for diagram types works in Azure DevOps. For example, we don't support most HTML tags, Font Awesome, `flowchart` syntax (`graph` used instead), or LongArrow `---->`. 
+
+Wiki supports the following Mermaid diagram types:
 
 - [Sequence diagrams](https://mermaid-js.github.io/mermaid/#/sequenceDiagram)
 - [Gantt charts](https://mermaid-js.github.io/mermaid/#/gantt)
@@ -63,8 +68,7 @@ Mermaid lets you create diagrams and visualizations using text and code. Wiki su
 For more information, see the [Mermaid release notes](https://github.com/mermaid-js/mermaid/releases).
 
 > [!NOTE]
-> - Not all syntax in the previously linked content for diagram types works in Azure DevOps. For example, we don't support most HTML tags, Font Awesome, or LongArrow `---->`. 
-> - Mermaid isn't supported in the Internet Explorer browser.
+> Mermaid isn't supported in the Internet Explorer browser.
 
 To add a Mermaid diagram to a wiki page, use the following syntax:
 


### PR DESCRIPTION
It didn't work for me that the documentation shows the link to the flowchart functionality in Mermaid but the keyword is not supported. 

This PR expands and rearranges the note about some functionality not being supported. 

<img src=https://user-images.githubusercontent.com/1097613/190961179-88eee061-8704-41f8-ac64-ec5a71f1d888.png
width=50% height=50% />


(other content here) 
<img src=https://user-images.githubusercontent.com/1097613/190960606-f64d1846-f878-453f-b2b9-1596a5ad55e3.png width=50% height=50% />


