### PR TITLE
fix: path for Go test is wrong

### DIFF
--- a/docs/pipelines/ecosystems/go.md
+++ b/docs/pipelines/ecosystems/go.md
@@ -186,7 +186,7 @@ Use `go test` to test your go module and its subdirectories (`./...`). Add the f
   inputs:
     command: 'test'
     arguments: '-v'
-    workingDirectory: '$(modulePath)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
 ```
 
 When you're ready, Commit a new _azure-pipelines.yml_ file to your repository and update the commit message. Select **Save and run**.


### PR DESCRIPTION
I am using Go 1.19.1 (latest at this time). The default snippet for testing results in this error:

`/opt/hostedtoolcache/go/1.19.1/x64/bin/go test -v ##[error]The Go task failed with an error: Error: There was an error when attempting to execute the process '/opt/hostedtoolcache/go/1.19.1/x64/bin/go'. This may indicate the process failed to start. Error: spawn /opt/hostedtoolcache/go/1.19.1/x64/bin/go ENOENT`

Fixing the path to `$(System.DefaultWorkingDirectory)` resolves the problem.