### PR TITLE
Correct the usage of QueryAzureDevOpsExtensionversion

### DIFF
--- a/docs/extend/develop/add-build-task.md
+++ b/docs/extend/develop/add-build-task.md
@@ -563,7 +563,7 @@ stages:
         steps:
           - task: TfxInstaller@3
             inputs:
-              version: "v0.7.x"
+              version: "v0.x"
           - task: Npm@1
             inputs:
               command: 'install'
@@ -590,7 +590,7 @@ stages:
         steps:
           - task: TfxInstaller@3
             inputs:
-              version: "v0.7.x"
+              version: "0.x"
           - task: Npm@1
             inputs:
               command: 'install'
@@ -602,21 +602,21 @@ stages:
               script: |
                 cd TaskDirectory # Update to the name of the directory of your task
                 tsc
-          - task: QueryAzureDevOpsExtensionVersion@3
+          - task: QueryAzureDevOpsExtensionVersion@4
+            name: QueryVersion
             inputs:
               connectTo: 'VsTeam'
               connectedServiceName: 'ServiceConnection' # Change to whatever you named the service connection
               publisherId: '$(PublisherID)'
               extensionId: '$(ExtensionID)'
               versionAction: 'Patch'
-              outputVariable: 'Task.Extension.Version'
           - task: PackageAzureDevOpsExtension@3
             inputs:
               rootFolder: '$(System.DefaultWorkingDirectory)'
               publisherId: '$(PublisherID)'
               extensionId: '$(ExtensionID)'
               extensionName: '$(ExtensionName)'
-              extensionVersion: '$(Task.Extension.Version)'
+              extensionVersion: '$(QueryVersion.Extension.Version)'
               updateTasksVersion: true
               updateTasksVersionType: 'patch'
               extensionVisibility: 'private' # Change to public if you're publishing to the marketplace
@@ -637,7 +637,7 @@ stages:
         steps:
           - task: TfxInstaller@3
             inputs:
-              version: "v0.7.x"
+              version: "v0.x"
           - task: DownloadBuildArtifacts@0
             inputs:
               buildType: "current"


### PR DESCRIPTION
See: https://stackoverflow.com/a/73609482/736079

The syntax has slightly changed with version 4, it now relies solely on output variables.

And I've updated tfx in the workflow to use `0.x`, so it won't use the ancient `0.7`.