### PR TITLE
Document required directory permissions workaround

### DIFF
--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -464,8 +464,6 @@ steps:
 - script: echo "##vso[task.prependpath]$CONDA/bin"
   displayName: Add conda to PATH
 
-# https://github.com/microsoft/azure-pipelines-tasks/issues/16203
-# https://github.com/microsoft/azure-pipelines-tasks/issues/12179
 - bash: |
     sudo chown -R $(whoami):$(id -ng) $(CONDA_CACHE_DIR)
   displayName: Fix CONDA_CACHE_DIR directory permissions

--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -464,6 +464,12 @@ steps:
 - script: echo "##vso[task.prependpath]$CONDA/bin"
   displayName: Add conda to PATH
 
+# https://github.com/microsoft/azure-pipelines-tasks/issues/16203
+# https://github.com/microsoft/azure-pipelines-tasks/issues/12179
+- bash: |
+    sudo chown -R $(whoami):$(id -ng) $(CONDA_CACHE_DIR)
+  displayName: Fix CONDA_CACHE_DIR directory permissions
+
 - task: Cache@2
   displayName: Use cached Anaconda environment
   inputs:


### PR DESCRIPTION
* For Conda
* The example will fail without this workaround applied