### PR TITLE
this removes the duplicate URL to fix issue #12799

### DIFF
--- a/docs/organizations/security/allow-list-ip-url.md
+++ b/docs/organizations/security/allow-list-ip-url.md
@@ -58,7 +58,6 @@ https://visualstudio.com
 https://vsrm.dev.azure.com
 https://vstsagentpackage.azureedge.net
 https://*.windows.net
-https://app.vssps.visualstudio.com 
 https://{organization_name}.visualstudio.com
 https://{organization_name}.vsrm.visualstudio.com
 https://{organization_name}.vstmr.visualstudio.com


### PR DESCRIPTION
The host `https://app.vssps.visualstudio.com` was explicitly stated twice, which makes it redundant and it can be removed.

I deliberately left it in once though (because one could argue its matched by `https://*.vssps.visualstudio.com`), so it shows up in searches. Also it depends on the firewall implementation if wildcard works as expected.