### PR TITLE
Document that task commands unescape their value

### DIFF
--- a/docs/pipelines/process/set-variables-scripts.md
+++ b/docs/pipelines/process/set-variables-scripts.md
@@ -271,3 +271,18 @@ Then, in a future stage, map the output variable `myStageVal` to a stage, job, o
 
 ---
 
+In case your value contains newlines, you can escape them and the agent will automatically unescape it:
+
+```yaml
+steps:
+    - bash: |
+        escape_data() {
+          local data=$1
+          data="${data//'%'/'%AZP25'}"
+          data="${data//$'\n'/'%0A'}"
+          data="${data//$'\r'/'%0D'}"
+          echo "$data"
+        }
+        echo "##vso[task.setvariable variable=myStageVal;isOutput=true]$(escape_data $'foo\nbar')"
+      name: MyOutputVar
+```


### PR DESCRIPTION
Here
https://github.com/microsoft/azure-pipelines-task-lib/blob/e69409b1c9b038296e8d67954adac50840d9dec6/node/taskcommand.ts#L93-L97 you can see that the official ADO pipeline tasks escape their data that they pass after the `]` of a `##vso` command.

As far as I can tell, this behavior is not yet documented at all. Especially in the context of `task.setvariable` it should be mentioned how to set variables that contain newlines.