### PR TITLE
clarify agentless task code example

### DIFF
--- a/docs/pipelines/process/phases.md
+++ b/docs/pipelines/process/phases.md
@@ -326,7 +326,7 @@ jobs:
     maxParallel: number
     matrix: { string: { string: string } }
 
-  pool: server
+  pool: server # note: the value 'server' is a reserved keyword which indicates this is an agentless job
 ```
 
 You can also use the simplified syntax:
@@ -334,7 +334,7 @@ You can also use the simplified syntax:
 ```yaml
 jobs:
 - job: string
-  pool: server
+  pool: server # note: the value 'server' is a reserved keyword which indicates this is an agentless job
 ```
 
 ::: moniker-end


### PR DESCRIPTION
The attribute of `pool: server` is not clear that `server` is a meaningful value and not just an example used for the code snippet.

It is not clear enough to immediately know that in order to make the task agentless the value of the `pool` attribute must be set to the string `server`.