### PR TITLE
Removing some use of '@' inside image alt text

### DIFF
--- a/docs/boards/queries/query-by-date-or-current-iteration.md
+++ b/docs/boards/queries/query-by-date-or-current-iteration.md
@@ -283,7 +283,7 @@ Any item assigned to a sprint that corresponds to the current iteration path for
 Azure Boards adds a team parameter when you select the **@CurrentIteration** or **@CurrentIteration +/- _n_** macros. The team parameter is derived from your current [team context](#team_view). 
 
 > [!div class="mx-imgBorder"]
-> ![Query filter using the @CurrentIteration macro with team parameter](media/query-date-iteration/at-current-with-team-parameter.png)  
+> ![Query filter using the CurrentIteration macro with team parameter](media/query-date-iteration/at-current-with-team-parameter.png)  
 
 > [!TIP]  
 > If the **@CurrentIteration** macro isn't working, check that the [expected iteration is selected for your team and that dates have been set for it](../../organizations/settings/set-iteration-paths-sprints.md#activate). 
@@ -300,7 +300,7 @@ To change the team parameter the system automatically sets, you choose it by typ
 Before creating or updating a query to use the **@CurrentIteration** macro, make sure you [select your team](#team_view). The **@CurrentIteration** macro references the current team selected in the web portal.  
 
 > [!div class="mx-imgBorder"]
-> ![Query filter using the @CurrentIteration macro](media/query-date-iteration/at-current-no-team-specified.png)  
+> ![Query filter using the CurrentIteration macro](media/query-date-iteration/at-current-no-team-specified.png)  
 
 ::: moniker-end
 


### PR DESCRIPTION
As a reader, this article appeared broken in a few places.

(Go to 'https://learn.microsoft.com/en-us/azure/devops/boards/queries/query-by-date-or-current-iteration?view=azure-devops' and search for the ` with team parameter" />` to see what I mean.

Investigation showed that the use of '@CurrentIteration' inside image alt-text was not being parsed/formatted correctly. It would be converted into "<span class="no-loc" dir="ltr" lang="en-us">@CurrentIteration</span>" -- but since it is emitted inside an alt-text... the first double quote would close the alt attribute, resulting in broken element, with the remainder of the alt-text rendered as html outside of the image.

Removing the `@` from inside the alt text seems like a pragmatic solution to fix the error without any loss of meaning.

(The "real bug" is with the tools doing the parsing/formatting, they might need to be smartened up to know when they are inside an alt text, and not try to produce HTML at that point.)

Love your work documenters -- you do great things.