### PR TITLE
Corrected example to update retention leases

### DIFF
--- a/docs/pipelines/build/run-retention.md
+++ b/docs/pipelines/build/run-retention.md
@@ -156,7 +156,7 @@ To [_update_ a retention lease](/rest/api/azure/devops/build/leases/update) requ
           $contentType = "application/json";
           $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };
           $rawRequest = @{ daysValid = 365 };
-          $request = ConvertTo-Json @($rawRequest);
+          $request = ConvertTo-Json $rawRequest;
           $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/retention/leases/$newLeaseId?api-version=7.1-preview.2";
           Invoke-RestMethod -uri $uri -method PATCH -Headers $headers -ContentType $contentType -Body $request;
 ```

--- a/docs/pipelines/build/run-retention.md
+++ b/docs/pipelines/build/run-retention.md
@@ -155,9 +155,9 @@ To [_update_ a retention lease](/rest/api/azure/devops/build/leases/update) requ
         script: |
           $contentType = "application/json";
           $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };
-          $rawRequest = @{ daysValid = 365; leaseId = $newLeaseId; ownerId = 'User:$(Build.RequestedForId)' };
+          $rawRequest = @{ daysValid = 365 };
           $request = ConvertTo-Json @($rawRequest);
-          $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/retention/leases?api-version=6.0-preview.2";
+          $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/retention/leases/$newLeaseId?api-version=7.1-preview.2";
           Invoke-RestMethod -uri $uri -method PATCH -Headers $headers -ContentType $contentType -Body $request;
 ```
 


### PR DESCRIPTION
Fixes #12858 with updated API method for changing the length of time a build is retained for.