### PR TITLE
Update PublishPipelineArtifactv1 doc to indicate that artifactType is an optional value

### DIFF
--- a/docs/pipelines/tasks/includes/yaml/PublishPipelineArtifactV1.md
+++ b/docs/pipelines/tasks/includes/yaml/PublishPipelineArtifactV1.md
@@ -13,7 +13,7 @@ ms.subservice: azure-devops-pipelines-tasks
   inputs:
     #path: '$(Pipeline.Workspace)' # Required. Default value: $(Pipeline.Workspace). Aliases: targetPath.
     #artifactName: 'drop' # Optional. Aliases: artifact.
-    #artifactType: 'pipeline' # Required. Options: pipeline, filepath. Default value: pipeline. Aliases: publishLocation.
+    #artifactType: 'pipeline' # Optional. Options: pipeline, filepath. Default value: pipeline. Aliases: publishLocation.
     #fileSharePath: '\server\folderName' # Required when artifactType = filepath.
     #parallel: false # Optional. Default value: false.
     #parallelCount: 1 # Optional. Value must be at least 1 and not greater than 128. Default value: 8

--- a/docs/pipelines/tasks/utility/publish-pipeline-artifact.md
+++ b/docs/pipelines/tasks/utility/publish-pipeline-artifact.md
@@ -32,8 +32,8 @@ Use this task in a pipeline to publish your artifacts(note that publishing is NO
 | -------- | ----------- |
 | `path`<br/>File or directory path | (Required) Path to the folder or file you want to publish. Wildcards aren't supported. The path must be a fully qualified path or a valid path relative to the root directory of your repository. See [Artifacts in Azure Pipelines](../../artifacts/pipeline-artifacts.md). |
 | `artifactName`<br/>Artifact name | (Optional) Specify the name of the artifact that you want to create. It can be whatever you want. For example: *drop* |
-| `artifactType`<br/>Artifact publish location | (Required) Artifacts publish location. Choose whether to publish your file as a pipeline artifact, or to copy it to a file share that must be accessible from the pipeline agent. Options: pipeline, filepath. Default value: pipeline |
-| `fileSharePath`<br/>File share path | (Optional) The file share path that the artifact will be published to. This can include variables. Required when `artifactType` = `filepath`. For example: `\server\folderName` |
+| `artifactType`<br/>Artifact publish location | (Optional) Artifacts publish location. Choose whether to publish your file as a pipeline artifact, or to copy it to a file share that must be accessible from the pipeline agent. Options: pipeline, filepath. Default value: pipeline |
+| `fileSharePath`<br/>File share path | (Optional) Required when `artifactType` = `filepath`. The file share path that the artifact will be published to. This can include variables. For example: `\server\folderName` |
 | `parallel`<br/>Parallel copy | (Optional) Select whether to copy files in parallel using multiple threads. If this setting isn't enabled, one thread will be used. Default value: false|
 | `parallelCount`<br/>Parallel count | (Optional) Enter the degree of parallelism, or number of threads used to publish a package. The value must be at least 1 and not greater than 128. |
 | `properties`<br/>Custom properties | (Optional) Enter custom properties to associate with the artifact. Valid JSON string expected with all keys having the prefix 'user-'. |


### PR DESCRIPTION
Task Name: PublishBuildArtifacts@1 doc update

Description:
* Update artifactType to be described as optional
* Move "optional required" information to the beginning of fileSharePath parameter description

Documentation changes required: Yes

Added unit tests: No
