### PR TITLE
Validating and troubleshooting webhooks

### DIFF
--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -758,6 +758,38 @@ Resource triggers can fail to execute for the following reasons.
 * If trigger conditions aren't matched, the trigger won't execute. A warning is surfaced so you can understand why the conditions weren't matched.  
 
    ![Trigger issues supportability](media/trigger-supportability.png)
+   
+## Validating and troubleshooting webhooks
+
+After creating your `service connection` and naming your webhook, ensure that you have a pipeline with the webhook and service connection referenced within resources -> webhooks
+```yml
+resources:
+  webhooks:
+    - webhook: MyWebhookTriggerAlias
+      connection: MyServiceConnection
+```
+and run the pipeline.  Running the pipeline at least once ensures the webhook is created at Azure as a distributed task within your `{organization}`.
+
+Perform a `POST` API call with any valid JSON in the body to 
+`https://dev.azure.com/{organization}/_apis/distributedtask/webhooks/{webhook-name}?api-version={apiversion}`.
+
+If you receive a 200 status code response, your webhook is ready for consumption by your pipeline.
+
+If you receive a 500 status code response, with the error `Cannot find webhook for the given webHookId <webhook-name-here>. Try enabling CD trigger for this artifact.`
+and your pipeline yaml is in a branch of your code that is *NOT* the default e.g. `feature/my-feature-branch`?
+1. Navigate to your pipeline
+1. Click 'Edit'
+1. Click the vertical ellipses beside 'Run'
+1. Click 'Triggers'
+1. Click the 'YAML' tab
+1. Click 'Get Sources'
+1. Select your feature branch under `Default branch for manual and scheduled builds`
+1. Click 'Save & queue'
+
+After this pipeline runs successfully to completion, perform a `POST` API call with any valid JSON in the body to 
+`https://dev.azure.com/{organization}/_apis/distributedtask/webhooks/{webhook-name}?api-version={apiversion}`.
+
+You should now receive a 200 status code response.
 
 ## Next steps
 


### PR DESCRIPTION
I'm adding a validating and troubleshooting section to the webhook documentation as I have spent multiple hours trying to figure out my webhook issue.  Each time it has been delivering my pipeline YAML to a feature branch (not the default) and creating the pipeline, pointing my pipeline to my feature branch YAML, and clicking 'RUN'.  This *looks* to all effects that it should work, but doing this does not seem to register the webhook to my organization's distributed tasks, thus giving me a 500 status code response every time that the webhook doesn't exist.  The steps above allow the user to deliver their code to a feature branch, and save and queue it from there.  From this point on, the webhook is registered correctly, and responds with a 200 status code.  The means of *getting* to the above via the UI are also not very apparent, so hopefully this will assist others who are also struggling with this.  I had only found 1 or 2 references when trying to research the problem I was facing.