### PR TITLE
fix condition for Docker cache save task

### DIFF
--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -277,7 +277,7 @@ steps:
       mkdir -p $(Pipeline.Workspace)/docker
       docker save -o $(Pipeline.Workspace)/docker/cache.tar $(repository):$(tag)
     displayName: Docker save
-    condition: and(not(canceled()), or(failed(), ne(variables.CACHE_RESTORED, 'true')))
+    condition: and(not(canceled()), not(failed()), ne(variables.CACHE_RESTORED, 'true'))
 ```
 
 - **key**: (required) - a unique identifier for the cache.


### PR DESCRIPTION
The cache should only be populated if the build was neither canceled nor failed, but the previous example would overwrite the cache when the build failed.

This PR changes the example's condition to be:

```
and(
  not(canceled()),
  not(failed()),
  ne(variables.CACHE_RESTORED, 'true')
)