### PR TITLE
Update Teams Maximum

### DIFF
--- a/docs/boards/plans/faqs.yml
+++ b/docs/boards/plans/faqs.yml
@@ -41,7 +41,7 @@ sections:
                 Teams, Backlogs
              :::column-end::: 
              :::column span="2":::
-                15 maximum
+                20 maximum
              :::column-end:::
              :::column span="2":::
                 10 maximum


### PR DESCRIPTION
Since September 12th the limit is 20 teams -> https://learn.microsoft.com/en-us/azure/devops/release-notes/2022/sprint-209-update?tabs=yaml#increase-delivery-plans-team-limit-from-15-to-20