### PR TITLE
Update deployment-jobs.md checkout step behaviour information

### DIFF
--- a/docs/pipelines/process/deployment-jobs.md
+++ b/docs/pipelines/process/deployment-jobs.md
@@ -25,7 +25,7 @@ Deployment jobs provide the following benefits:
    > [!NOTE] 
    > We currently support only the *runOnce*, *rolling*, and the *canary* strategies.  
 
-A deployment job doesn't automatically clone the source repo. You can checkout the source repo within your job with `checkout: self`. Deployment jobs only support one checkout step. 
+A deployment job doesn't automatically clone the source repo. You can checkout the source repo within your job with `checkout: self`.
 
 ## Schema
 


### PR DESCRIPTION
Remove the message about deployment jobs only supporting one checkout step.
This no longer appears to be the case, as the following pipeline template works with two checkout steps.
This appears to have been added after this issue #11188 

````
- stage: Terraform_Apply
    displayName: "Terraform Apply"
    dependsOn: Terraform_Plan
    condition: and(succeeded('Terraform_Plan'), eq(dependencies.Terraform_Plan.outputs['TerraformPlanJob.terraformPlan.changesPresent'], 'true'))
    variables:
      - name: TF_IN_AUTOMATION
        value: true
    jobs:
      - deployment: TerraformApply
        displayName: "Terraform Apply"
        pool:
          vmimage: "ubuntu-latest"
        environment: "${{ parameters.azdoEnvironment }}"
        strategy:
          runOnce:
            deploy:
              steps:
                - checkout: self
                  displayName: Checkout Self Repo

                - checkout: git://DEMO/DEMO_Scripts
                  displayName: Checkout DEMO_Scripts
````