### PR TITLE
Fix typo in upstream-sources.md

### DIFF
--- a/docs/artifacts/npm/upstream-sources.md
+++ b/docs/artifacts/npm/upstream-sources.md
@@ -63,7 +63,7 @@ You can view the packages you saved from upstreams by selecting your **Source** 
 
 ## Scopes
 
-Using scopes instead of upstream sources limit your private package consumption to those with the `@scope` prefix e.g. `@fabrikam/core` but enable you to consume public packages **directly** from npmjs.com, see [npm scopes](scopes.md) for more details.
+Using scopes instead of upstream sources limits your private package consumption to those with the `@scope` prefix e.g. `@fabrikam/core` but enables you to consume public packages **directly** from npmjs.com, see [npm scopes](scopes.md) for more details.
 
 ## Related articles
 


### PR DESCRIPTION
Change this:

> Using scopes instead of upstream sources **limit** your private package consumption to those with the `@scope` prefix e.g. `@fabrikam/core` but **enable** you...

To this:

> Using scopes instead of upstream sources **limits** your private package consumption to those with the `@scope` prefix e.g. `@fabrikam/core` but **enables** you...