### PR TITLE
Fix typo in artifactignore.md

### DIFF
--- a/docs/artifacts/reference/artifactignore.md
+++ b/docs/artifacts/reference/artifactignore.md
@@ -36,7 +36,7 @@ In the following example, we will be ignoring all files except the ones in the *
 The *.artifactignore* follows the same syntax as the [.gitignore](https://git-scm.com/docs/gitignore) with some minor limitations. The plus sign character `+` is not supported in URL paths and some of the semantic versioning metadata for some package types like Maven.
 
 > [!Note]
-> *.git* file is ignored by default if you don't have an *.artifactignore* file. You can re-include it by creating an empty *.artifactignore* file.
+> The *.git* folder is ignored by default if you don't have an *.artifactignore* file. You can re-include it by creating an empty *.artifactignore* file.
 
 ## Related articles
 

--- a/docs/artifacts/reference/artifactignore.md
+++ b/docs/artifacts/reference/artifactignore.md
@@ -36,7 +36,7 @@ In the following example, we will be ignoring all files except the ones in the *
 The *.artifactignore* follows the same syntax as the [.gitignore](https://git-scm.com/docs/gitignore) with some minor limitations. The plus sign character `+` is not supported in URL paths and some of the semantic versioning metadata for some package types like Maven.
 
 > [!Note]
-> The *.git* folder is ignored by default if you don't have an *.artifactignore* file. You can re-include it by creating an empty *.artifactignore* file.
+> The *.gitignore* file is ignored by default if you don't have an *.artifactignore* file. You can re-include it by creating an empty *.artifactignore* file.
 
 ## Related articles
 


### PR DESCRIPTION
The note text below:

> .git file is ignored by default if you don't have an .artifactignore file....

...mentions a **.git file** when it should probably say **the .git folder** just like in the note text [over here]( https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#use-artifactignore):

![image](https://user-images.githubusercontent.com/20465797/211447262-0fb813a0-c66d-4241-aa60-d822e657a3a2.png)
