### PR TITLE
Add libicu66 installation to ubuntu 20.04 example

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -217,7 +217,8 @@ Next, create the Dockerfile.
           iputils-ping \
           jq \
           lsb-release \
-          software-properties-common
+          software-properties-common \
+          libicu66
 
       RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 


### PR DESCRIPTION
When starting the Docker image built from the Ubuntu 20.04 example, it might output an error:

libicu's dependencies missing for .NET Core 3.1
Execute ./bin/installdependencies.sh to install any missing dependencies.

Since we cannot run ./bin/installdependencies.sh manually in a container (or at the least it would seem it does not make sense), I would say, installing libicu in the Docker image build section would be more reasonable.

Another solution would be to start the script automatically in ./config.sh (https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Misc/layoutroot/config.sh#L63), if libicu is not installed, but, since the config.sh script is also used when installing agents as a Linux service, it might be good to keep it as a manual step for the systemd users.