### PR TITLE
Fixed code sample

### DIFF
--- a/docs/pipelines/build/run-retention.md
+++ b/docs/pipelines/build/run-retention.md
@@ -168,7 +168,7 @@ To [_update_ a retention lease](/rest/api/azure/devops/build/leases/update) requ
           $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };
           $rawRequest = @{ daysValid = 365 };
           $request = ConvertTo-Json $rawRequest;
-          $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/retention/leases/$newLeaseId?api-version=7.1-preview.2";
+          $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/retention/leases/$(newLeaseId)?api-version=7.1-preview.2";
           Invoke-RestMethod -uri $uri -method PATCH -Headers $headers -ContentType $contentType -Body $request;
 ```
 


### PR DESCRIPTION
Fixed the code sample in section:

> [Example: Updating the retention window for a multi-stage pipeline based on stage success](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/run-retention?view=azure-devops&tabs=powershell&WT.mc_id=DOP-MVP-21138#example-updating-the-retention-window-for-a-multi-stage-pipeline-based-on-stage-success)

In the "release" part of the sample:
* `$newLeaseId` is undefined (and thus empty)
* Changed to `$(newLeaseId)` to make it work
