### PR TITLE
Corrected typo in code

### DIFF
--- a/docs/pipelines/process/run-number.md
+++ b/docs/pipelines/process/run-number.md
@@ -27,7 +27,7 @@ You can give runs much more useful names that are meaningful to your team.
 You can use a combination of tokens, variables, and underscore characters.
 
 ```yaml
-name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:r)
 
 steps:
   - script: echo '$(Build.BuildNumber)' # outputs customized build number like project_def_master_20200828.1


### PR DESCRIPTION
Removed a period from $(Rev:.r) so that it correctly reads $(Rev:r). Before the correction, a syntax error occurred when using the sample code. Now it works correctly.