### PR TITLE
Fix typo (securing -> security)

### DIFF
--- a/docs/pipelines/process/set-variables-scripts.md
+++ b/docs/pipelines/process/set-variables-scripts.md
@@ -68,7 +68,7 @@ The `task.setvariable` command includes properties for setting a variable as sec
 
 To use the variable in the next stage, set the `isoutput` property to `true`. To reference a variable with the `isoutput` set to true, you'll include the task name. For example, `$(TaskName.myVar)`. 
 
-When you set a variable as read only, it can't be overwritten by downstream tasks. Set `isreadonly` to `true`. Setting a variable as read only enhances securing by making that variable immutable. 
+When you set a variable as read only, it can't be overwritten by downstream tasks. Set `isreadonly` to `true`. Setting a variable as read only enhances security by making that variable immutable. 
 
 
 ## Set a variable as secret


### PR DESCRIPTION
Very minor typo fix - a little pedantic but caused me to have a double-read of the paragraph so I'm sure it has for others as well.