### PR TITLE
Fix no buttons value in dialog

### DIFF
--- a/docs/extend/develop/using-host-dialog.md
+++ b/docs/extend/develop/using-host-dialog.md
@@ -238,14 +238,14 @@ The `okText` and `cancelText` attributes can be used to specify alternate titles
     };
 ```
 
-To not show any buttons on the dialog, you can set the `buttons` attribute to `null`:
+To not show any buttons on the dialog, you can set the `buttons` attribute to `[]`:
 
 ```javascript
     var dialogOptions = {
         title: "My Dialog Title",
         width: 800,
         height: 600,
-        buttons: null
+        buttons: []
     };
 ```
 


### PR DESCRIPTION
Fixed the code example for no buttons in [Modal Dialog](https://learn.microsoft.com/en-us/azure/devops/extend/develop/using-host-dialog?view=azure-devops#customizing-the-dialog-buttons)

`null` seems not to work but `[]` does