### PR TITLE
Add configuration under Configure Jenkins header

### DIFF
--- a/docs/service-hooks/services/jenkins.md
+++ b/docs/service-hooks/services/jenkins.md
@@ -24,6 +24,12 @@ Git repository or when you check in code to Team Foundation version control.
 
 2. If you're setting up Jenkins on-premises, [enable HTTPS](https://jenkins.io/doc/book/installing/#configuring-http).
 
+3. Add or change `hudson.plugins.git.GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL` [system property](https://plugins.jenkins.io/git/#plugin-content-push-notification-from-repository) as disabled before -jar parameter inside of `<arguments>`  in `jenkins.xml` configuration file.
+
+   `
+   -Dhudson.plugins.git.GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL=disabled
+   `
+
 ## Set up a Jenkins build
 
 1. In Jenkins, create a new item.


### PR DESCRIPTION
Service hooks could not send post request to Jenkins at the 4th step of Trigger Jenkins header without token.

`hudson.plugins.git.GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL` argument should be defined as `disabled` to send post request to successfully in `jenkins.xml` file.

Related plugin: https://plugins.jenkins.io/git/
Related bug: https://issues.jenkins.io/browse/JENKINS-69208