### PR TITLE
Fixing Broken Image on "Connect Azure Boards to an Office client"

### DIFF
--- a/docs/boards/backlogs/office/track-work.md
+++ b/docs/boards/backlogs/office/track-work.md
@@ -232,9 +232,7 @@ This connection method requires that you have installed [Azure DevOps Open in Ex
    >    
    > 	
    >    
-   > ![QUery Results, context menu, Open in Excel Open Boards
-   >    
-   > Queries, vertical nav](media/connect/open-in-excel-from-portal.png)
+   > ![QUery Results, context menu, Open in Excel Open Boards Queries, vertical nav](media/connect/open-in-excel-from-portal.png)
 
 ### [Connect from client to Azure Boards](#tab/open-excel-cloud)
 

--- a/docs/boards/backlogs/office/track-work.md
+++ b/docs/boards/backlogs/office/track-work.md
@@ -223,9 +223,7 @@ This connection method requires that you have installed [Azure DevOps Open in Ex
    >    
    > 	
    >    
-   > ![Open Boards
-   >    
-   > Queries, vertical nav](/azure/devops/boards/queries/media/view-run-queries/open-queries-vert.png)
+   > ![Open Boards Queries, vertical nav](/docs/boards/queries/media/view-run-queries/open-queries-vert.png)
 
 1. Choose the query you want to open in Excel.
 


### PR DESCRIPTION
There was a broken image link on https://learn.microsoft.com/en-us/azure/devops/boards/backlogs/office/track-work?view=azure-devops&tabs=open-excel, I edited the markdown so the image is properly displayed.

![broken-image](https://user-images.githubusercontent.com/20507092/220034753-82f2532c-2b1c-40e1-afda-783deb4e77a7.png)
**Figure: broken image on the above link**

My change successfully fixes the broken image on the page by correctly closing the brackets.