### PR TITLE
Added Organization name length limitation

### DIFF
--- a/docs/includes/organization-name-limitation.md
+++ b/docs/includes/organization-name-limitation.md
@@ -3,4 +3,4 @@ ms.topic: include
 ---
 
 > [!IMPORTANT]
-> Currently, you can only use letters from the English alphabet in your organization name. Start organization names with a letter or number, followed by letters, numbers or hyphens, and they must end with a letter or number. And it must not contain more than 50 characters in length.
+> Currently, you can only use letters from the English alphabet in your organization name. Start organization names with a letter or number, followed by letters, numbers or hyphens. Organization names can't be longer than 50 characters and must end with a letter or number.

--- a/docs/includes/organization-name-limitation.md
+++ b/docs/includes/organization-name-limitation.md
@@ -3,4 +3,4 @@ ms.topic: include
 ---
 
 > [!IMPORTANT]
-> Currently, you can only use letters from the English alphabet in your organization name. Start organization names with a letter or number, followed by letters, numbers or hyphens, and they must end with a letter or number.
+> Currently, you can only use letters from the English alphabet in your organization name. Start organization names with a letter or number, followed by letters, numbers or hyphens, and they must end with a letter or number. And it must not contain more than 50 characters in length.


### PR DESCRIPTION
The maximum length of an organization name is 50 characters. Setting more than 51 characters will result in an error.

Error message:
The given organization name is not valid. Organization names cannot be longer than 50 characters.

Screenshot:
![image](https://user-images.githubusercontent.com/93104616/221740041-00f93f5c-b1bc-4bf7-9fdf-fcd776ce26f6.png)
