### PR TITLE
Add glossary PBI acronym

### DIFF
--- a/docs/includes/glossary-terms/product-backlog-item.md
+++ b/docs/includes/glossary-terms/product-backlog-item.md
@@ -2,5 +2,5 @@
 ms.topic: include
 ---
 
-## Product backlog item
+## Product backlog item (PBI)
 A type of work item that defines the applications, requirements, and elements that teams plan to create. Product owners typically define and stack rank product backlog items which are defined with the Scrum process.  Learn more: [Scrum process work item types and workflow](../../boards/work-items/guidance/scrum-process-workflow.md).


### PR DESCRIPTION
Other pages don't spell out this acronym (e.g., https://learn.microsoft.com/en-us/azure/devops/boards/plans/visibility-across-teams?view=azure-devops), but it should be referable within the glossary (like is the case for [WITs](https://github.com/MicrosoftDocs/azure-devops-docs/blob/main/docs/includes/glossary-terms/work-item-types.md) etc.). 
