### PR TITLE
Update restrict-invitations.md

### DIFF
--- a/docs/organizations/security/restrict-invitations.md
+++ b/docs/organizations/security/restrict-invitations.md
@@ -49,6 +49,14 @@ Now, only Project Collection Administrators can invite new users to Azure DevOps
 > [!NOTE]
 > **Known limitation:** Even with the policy turned off, Team and Project Administrators can re-invite users who were previously members of the organization. 
 
+## When policy is enabled
+
+Project and Team Admins will be able to add users directly from their permissions blade inside their projects.
+If they try to add users from the Organization Settings > Users; the _Add Users_ button will not be visible for them.
+
+When adding a user directly from Project Settings > Permissions, the added user will not automatically appear in the Organization Settings > Users list.
+It will require a login of the recently added user to materialize the identity within the Users list.
+
 ## Related articles
 - [Default permissions and access](permissions-access.md) 
 - [Permission lookup guide](permissions-lookup-guide.md) 

--- a/docs/organizations/security/restrict-invitations.md
+++ b/docs/organizations/security/restrict-invitations.md
@@ -8,7 +8,7 @@ ms.subservice: azure-devops-security
 ms.author: chcomley
 author: chcomley
 monikerRange: 'azure-devops'
-ms.date: 02/12/2021
+ms.date: 03/02/2023
 ---
 
 # Restrict new user invitations from Project and Team Administrators 
@@ -47,15 +47,11 @@ You must be a member of the [Project Collection Administrators group](../securit
 Now, only Project Collection Administrators can invite new users to Azure DevOps.
 
 > [!NOTE]
-> **Known limitation:** Even with the policy turned off, Team and Project Administrators can re-invite users who were previously members of the organization. 
+> Project and Team Administrators can directly add users to their projects through the permissions blade. However, if they attempt to add users through the **Add Users** button located in the **Organization settings** > **Users** section, it's not visible to them.
+> Adding a user directly through **Project settings** > **Permissions** doesn't result in the user appearing automatically in the **Organization settings** > **Users** list. For the user to be reflected in the Users list, they must sign in to the system.
 
-## When policy is enabled
-
-Project and Team Admins will be able to add users directly from their permissions blade inside their projects.
-If they try to add users from the Organization Settings > Users; the _Add Users_ button will not be visible for them.
-
-When adding a user directly from Project Settings > Permissions, the added user will not automatically appear in the Organization Settings > Users list.
-It will require a login of the recently added user to materialize the identity within the Users list.
+### Known limitation
+Even with the policy turned off, Team and Project Administrators can re-invite users who were previously members of the organization. 
 
 ## Related articles
 - [Default permissions and access](permissions-access.md) 


### PR DESCRIPTION
Adding details of how to add users when the policy is enabled Confusing as the Add button will not show for the Project and Team Admins even when policy is enabled