### PR TITLE
Added caution info box to indicate unavailable option

### DIFF
--- a/docs/pipelines/library/service-endpoints.md
+++ b/docs/pipelines/library/service-endpoints.md
@@ -542,6 +542,9 @@ For an Azure RBAC disabled cluster, a ServiceAccount gets created in the chosen 
 > [!NOTE]
 > This option lists all the subscriptions the service connection creator has access to *across different Azure tenants*. If you can't see subscriptions from other Azure tenants, check your Azure AD permissions in those tenants.
 
+> [!CAUTION]
+> Starting with Kubernetes version 1.24 and above, this option will no longer be supported. Please refer to the alternative options below instead.
+
 #### Service account option
 
 | Parameter | Description |


### PR DESCRIPTION
Based on various closed developer community posts (e.g.: https://developercommunity.visualstudio.com/t/MS-DevOps-Environment--Cannot-Add-Resou/10154315?viewtype=solutions), adding a Kubernetes resource/service connection in Azure DevOps using the "Azure Subscription" option is no longer possible starting with Kubernetes version 1.24 and above. If this option is no longer supported, it should be documented accordingly.