### PR TITLE
Update link to macOS install instructions in set-up-credential-managers.md

### DIFF
--- a/docs/repos/git/set-up-credential-managers.md
+++ b/docs/repos/git/set-up-credential-managers.md
@@ -37,7 +37,7 @@ Download and run the latest [Git for Windows installer](https://git-scm.com/down
 You may [use SSH keys](use-ssh-keys-to-authenticate.md) to authenticate to Azure Repos, or you may use [Git Credential Manager](https://github.com/GitCredentialManager/git-credential-manager).
 
 Installation instructions are included in the GitHub repository for GCM.
-On Mac, we recommend using [Homebrew](https://github.com/GitCredentialManager/git-credential-manager#macos-homebrew).
+On Mac, we recommend using [Homebrew](https://github.com/git-ecosystem/git-credential-manager/blob/release/docs/install.md#macos).
 On Linux, you can install from a [.deb](https://github.com/GitCredentialManager/git-credential-manager#ubuntudebian-distributions) or a [tarball](https://github.com/GitCredentialManager/git-credential-manager#other-distributions).
 
 ## Using the Git Credential Manager


### PR DESCRIPTION
Fix link pointing to macOS Homebrew installation instructions.