### PR TITLE
Remove dollar sign from command example in CLI doc

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -46,7 +46,7 @@ Adding the Azure DevOps Extension adds `devops`, `pipelines`, `artifacts`, `boar
 For usage and help content for any command, enter the **-h** parameter, for example:
 
 ```azurecli
-$ az devops -h
+az devops -h
 ```
 
 ```output


### PR DESCRIPTION
The "Command usage" example has a $ at the start - the other examples do not have this and using the copy button copies the $ to the clipboard.