### PR TITLE
fix: semantic search header with moniker new-line (#13221)

### DIFF
--- a/docs/boards/queries/search-box-queries.md
+++ b/docs/boards/queries/search-box-queries.md
@@ -170,6 +170,7 @@ Free text search easily searches across all work item fields, including custom f
 
 4. Narrow your search to specific types
    and states, by using the drop-down selector lists at the top of the results page.
+
 ::: moniker-end
 
 <a id="start-an-improvised-search-and-use-shortcut-filters" />


### PR DESCRIPTION
This PR is attempts to solve a header that is not being rendered correctly (please see #13221).
The header is correctly recognised in markdown preview (both before and after my commit). But please do let me know if there is a way to check locally if the header is recognised after being rendered to .html etc.?
Fixes https://github.com/MicrosoftDocs/azure-devops-docs/issues/13221

CC @WilliamAntonRohm 