### PR TITLE
Correction in verison of AKS that supports Docker in Docker

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -443,7 +443,7 @@ If you're sure you want to do this, see the [bind mount](https://docs.docker.com
 ## Use Azure Kubernetes Service cluster
 
 > [!CAUTION]
-> Please, consider that any docker based tasks will not work on AKS 1.19 or earlier due to docker in docker restriction. 
+> Please, consider that any docker based tasks will not work on AKS 1.19 or later due to docker in docker restriction. 
 > [Docker was replaced with containerd](/azure/aks/cluster-configuration#container-runtime-configuration) in Kubernetes 1.19, and Docker-in-Docker became unavailable.
 
 ### Deploy and configure Azure Kubernetes Service 


### PR DESCRIPTION
The document says "docker based tasks will not work on AKS 1.19 or **earlier**". 

It rather should be "docker based tasks will not work on AKS 1.19 or **later**" as after introduction to **containerd**, AKS will not support Docker in Docker.