### PR TITLE
Update multi-repo-checkout.md (Triggering repository has to be explicitly checked out)

### DIFF
--- a/docs/pipelines/repos/multi-repo-checkout.md
+++ b/docs/pipelines/repos/multi-repo-checkout.md
@@ -294,6 +294,10 @@ resources:
     trigger:
     - main
     - release
+  steps:
+  - checkout: self
+  - checkout: A
+  - checkout: B
 ```
 
 The following table shows which versions are checked out for each repository by a pipeline using the above YAML file, unless you explicitly override the behavior during `checkout`.


### PR DESCRIPTION
On Line 272, removed this part of the line ", unless you explicitly override the behavior during checkout." Because the triggering repository is not automatically checkout (an internal bug was created and this information is tested and verified with PM).   

In the Yaml, added lines 297 to 300, so that the information in the Table that follows will still be applicable.