### PR TITLE
Update multi-repo-checkout.md 

### DIFF
--- a/docs/pipelines/repos/multi-repo-checkout.md
+++ b/docs/pipelines/repos/multi-repo-checkout.md
@@ -296,7 +296,7 @@ resources:
     - release
 ```
 
-The following table shows which versions are checked out for each repository by a pipeline using the above YAML file, unless you explicitly override the behavior during `checkout`.
+The following table shows which versions are checked out for each repository by a pipeline using the above YAML file.
 
 | Change made to | Pipeline triggered | Version of YAML | Version of `self` | Version of `A` | Version of `B` |
 |----------------|--------------------|-----------------|-------------------|----------------|----------------|


### PR DESCRIPTION
-Updated line 299 by removing this part ", unless you explicitly override the behavior during checkout." Because the triggering repository is not automatically checkout (an internal bug was created and this information is tested and verified with PM).

- No changes in line 272 as mentioned in this PR: https://github.com/MicrosoftDocs/azure-devops-docs/pull/13293
- missed to make this change to line 299 in the previous PR: https://github.com/MicrosoftDocs/azure-devops-docs/pull/13293