### PR TITLE
Update multi-repo-checkout.md

### DIFF
--- a/docs/pipelines/repos/multi-repo-checkout.md
+++ b/docs/pipelines/repos/multi-repo-checkout.md
@@ -294,9 +294,13 @@ resources:
     trigger:
     - main
     - release
+steps
+- checkout: self
+- checkout: A
+- checkout: B
 ```
 
-The following table shows which versions are checked out for each repository by a pipeline using the above YAML file, unless you explicitly override the behavior during `checkout`.
+The following table shows which versions are checked out for each repository by a pipeline using the above YAML file.
 
 | Change made to | Pipeline triggered | Version of YAML | Version of `self` | Version of `A` | Version of `B` |
 |----------------|--------------------|-----------------|-------------------|----------------|----------------|

--- a/docs/pipelines/repos/multi-repo-checkout.md
+++ b/docs/pipelines/repos/multi-repo-checkout.md
@@ -294,7 +294,7 @@ resources:
     trigger:
     - main
     - release
-steps
+steps:
 - checkout: self
 - checkout: A
 - checkout: B


### PR DESCRIPTION
1. In the Yaml, added lines 297 to 300, so that the information in the Table that follows will still be applicable.

2. Modified original line 299 (now 303). Removed this part of the line ", unless you explicitly override the behavior during checkout". Because the triggering repository is not automatically checkout (an internal bug was created and this information is tested and verified with PM).

Please disregard/cancel, the previous 2 PRs:  

https://github.com/MicrosoftDocs/azure-devops-docs/pull/13293 https://github.com/MicrosoftDocs/azure-devops-docs/pull/13294