### PR TITLE
Update scale-set-agents.md - Removed /generalize from SysPrep command

### DIFF
--- a/docs/pipelines/agents/scale-set-agents.md
+++ b/docs/pipelines/agents/scale-set-agents.md
@@ -359,7 +359,7 @@ If you just want to create a scale set with the default 128-GB OS disk using a p
       
     - **Windows** - From an admin console window: 
       ```console
-      C:\Windows\System32\sysprep\sysprep.exe /generalize /oobe /shutdown
+      C:\Windows\System32\sysprep\sysprep.exe /oobe /shutdown
       ```
     - **Linux**:
       ```bash


### PR DESCRIPTION
Including /generalize resulted in an image that would cause the DevOps Agent to hang at startup instead of properly starting. Running sysprep WITHOUT /generalize resulted in a properly functioning DevOps Agent. Is /generalize needed or can it be removed from these instructions?