### PR TITLE
service accounts no longer have automatic long life tokens

### DIFF
--- a/docs/pipelines/process/environments-kubernetes.md
+++ b/docs/pipelines/process/environments-kubernetes.md
@@ -66,21 +66,34 @@ For more information about setting up a Kubernetes service connection outside of
    kubectl config view --minify -o 'jsonpath={.clusters[0].cluster.server}'
    ```
 
-5. To get your secret object, find the service account secret name.
+5. To get the secret object.
 
+    #### Kubernetes 1.22+
+    Replace `service-account-name` with your account name.
+   ```
+   kubectl get secret -n <namespace>  -o jsonpath='{.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=="service-account-name")]}'
+   ```
+    If you get nothing, see here how to create: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount
+
+   #### Kubernetes 1.22 and below:
+    1. Find the service account secret name
    ```
    kubectl get serviceAccounts <service-account-name> -n <namespace> -o 'jsonpath={.secrets[*].name}'
    ```
+    2. replace `<service-account-secret-name>` with the value in previous command in this command
+   ```
+   kubectl get secret <service-account-secret-name> -n <namespace> -o json
+   ```
 
-6. Get the secret object using the output of the previous step.
+5. Get the secret object using the output of the previous step.
 
    ```
    kubectl get secret <service-account-secret-name> -n <namespace> -o json
    ```
 
-7. Copy and paste the Secret object fetched in JSON form into the Secret field.
+6. Copy and paste the Secret object fetched in JSON form into the Secret field.
 
-8. Select **Validate and create** to create the Kubernetes resource.
+7. Select **Validate and create** to create the Kubernetes resource.
 
 ## Reference your Kubernetes resources in a pipeline
 

--- a/docs/pipelines/process/environments-kubernetes.md
+++ b/docs/pipelines/process/environments-kubernetes.md
@@ -73,7 +73,7 @@ For more information about setting up a Kubernetes service connection outside of
    ```
    kubectl get secret -n <namespace>  -o jsonpath='{.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=="service-account-name")]}'
    ```
-    If you get nothing, see here how to create: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount
+    If you get nothing, see [Manually create a long-lived API token for a ServiceAccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount).
 
    #### Kubernetes 1.22 and below:
     1. Find the service account secret name


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-an-api-token-for-a-serviceaccount

says:


Note:
Versions of Kubernetes before v1.22 automatically created long term credentials for accessing the Kubernetes API. This older mechanism was based on creating token Secrets that could then be mounted into running Pods. In more recent versions, including Kubernetes v1.27, API credentials are obtained directly by using the TokenRequest API, and are mounted into Pods using a projected volume. The tokens obtained using this method have bounded lifetimes, and are automatically invalidated when the Pod they are mounted into is deleted.

You can still manually create a service account token Secret; for example, if you need a token that never expires. However, using the TokenRequest subresource to obtain a token to access the API is recommended instead.