### PR TITLE
docs(python): incorrect sample project referenced

### DIFF
--- a/docs/pipelines/ecosystems/python.md
+++ b/docs/pipelines/ecosystems/python.md
@@ -59,7 +59,7 @@ https://github.com/Microsoft/python-sample-vscode-flask-tutorial
 
 1. If you're redirected to GitHub to sign in, enter your GitHub credentials.
 
-1. When the list of repositories appears, select your Node.js sample repository.
+1. When the list of repositories appears, select your Python sample repository.
 
 1. Azure Pipelines analyzes the code in your repository and recommends the `Python package` template for your pipeline. Select that template.
 


### PR DESCRIPTION
steps require the use to clone a python sample project. wording updated to mention the correct project type of Python, rather than Node.js