### PR TITLE
Improved caching

### DIFF
--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -288,22 +288,19 @@ steps:
 
 ## Golang
 
-For Golang projects, you can specify the packages to be downloaded in the *go.mod* file. If your `GOCACHE` variable isn't already set, set it to where you want the cache to be downloaded.
+For Golang projects, you can specify the packages to be downloaded in the *go.mod* file.
 
 **Example**:
 
 ```yaml
-variables:
-  GO_CACHE_DIR: $(Pipeline.Workspace)/.cache/go-build/
-
 steps:
 - task: Cache@2
   inputs:
     key: 'go | "$(Agent.OS)" | go.mod'
-    restoreKeys: | 
+    restoreKeys: |
       go | "$(Agent.OS)"
-    path: $(GO_CACHE_DIR)
-  displayName: Cache GO packages
+    path: /home/vsts/go/pkg/mod
+  displayName: Configure Go caching
 
 ```
 
@@ -314,9 +311,6 @@ Using Gradle's [built-in caching support](https://docs.gradle.org/current/usergu
 **Example**:
 
 ```yaml
-variables:
-  GRADLE_USER_HOME: $(Pipeline.Workspace)/.gradle
-
 steps:
 - task: Cache@2
   inputs:
@@ -324,8 +318,8 @@ steps:
     restoreKeys: |
       gradle | "$(Agent.OS)"
       gradle
-    path: $(GRADLE_USER_HOME)
-  displayName: Configure gradle caching
+    path: /home/vsts/.gradle/caches
+  displayName: Configure Gradle caching
 
 - task: Gradle@2
   inputs:
@@ -334,9 +328,9 @@ steps:
     options: '--build-cache'
   displayName: Build
 
-- script: |   
+- script: |
     # stop the Gradle daemon to ensure no files are left open (impacting the save cache operation later)
-    ./gradlew --stop    
+    ./gradlew --stop
   displayName: Gradlew stop
 ```
 
@@ -347,15 +341,11 @@ steps:
 
 ## Maven
 
-Maven has a local repository where it stores downloads and built artifacts. To enable, set the `maven.repo.local` option to a path under `$(Pipeline.Workspace)` and cache this folder.
+Maven has a local repository where it stores downloads and built artifacts.
 
 **Example**:
 
 ```yaml
-variables:
-  MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
-  MAVEN_OPTS: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-
 steps:
 - task: Cache@2
   inputs:
@@ -363,19 +353,10 @@ steps:
     restoreKeys: |
       maven | "$(Agent.OS)"
       maven
-    path: $(MAVEN_CACHE_FOLDER)
-  displayName: Cache Maven local repo
+    path: /home/vsts/.m2/repository
+  displayName: Configure Maven caching
 
 - script: mvn install -B -e
-```
-
-If you're using a [Maven task](/azure/devops/pipelines/tasks/reference/maven-v3), make sure to also pass the `MAVEN_OPTS` variable because it gets overwritten otherwise:
-
-```yaml
-- task: Maven@4
-  inputs:
-    mavenPomFile: 'pom.xml'
-    mavenOptions: '-Xmx3072m $(MAVEN_OPTS)'
 ```
 
 ## .NET/NuGet

--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -34,7 +34,7 @@ Pipeline caching and [pipeline artifacts](../artifacts/pipeline-artifacts.md) pe
 
 Caching is added to a pipeline using the [Cache task](/azure/devops/pipelines/tasks/reference/cache-v2). This task works like any other task and is added to the `steps` section of a job.
 
-When a cache step is encountered during a run, the task restores the cache based on the provided inputs. If no cache is found, the step completes and the next step in the job is run. 
+When a cache step is encountered during a run, the task restores the cache based on the provided inputs. If no cache is found, the step completes and the next step in the job is run.
 
 After all steps in the job have run and assuming a **successful** job status, a special **"Post-job: Cache"** step is automatically added and triggered for each **"restore cache"** step that wasn't skipped. This step is responsible for **saving the cache**.
 
@@ -56,7 +56,7 @@ The [Cache task](/azure/devops/pipelines/tasks/reference/cache-v2) has two requi
 Fixed value (like the name of the cache or a tool name) or taken from an environment variable (like the current OS or current job name)
 
 * **File paths**: <br>
-Path to a specific file whose contents will be hashed. This file must exist at the time the task is run. Keep in mind that *any* key segment that "looks like a file path" will be treated like a file path. In particular, this includes segments containing a `.`. This could result in the task failing when this "file" doesn't exist. 
+Path to a specific file whose contents will be hashed. This file must exist at the time the task is run. Keep in mind that *any* key segment that "looks like a file path" will be treated like a file path. In particular, this includes segments containing a `.`. This could result in the task failing when this "file" doesn't exist.
   > [!TIP]
   > To avoid a path-like string segment from being treated like a file path, wrap it with double quotes, for example: `"my.key" | $(Agent.OS) | key.file`
 
@@ -209,7 +209,7 @@ steps:
   displayName: Bundler caching
   inputs:
     key: 'gems | "$(Agent.OS)" | Gemfile.lock'
-    restoreKeys: | 
+    restoreKeys: |
       gems | "$(Agent.OS)"
       gems
     path: $(BUNDLE_PATH)
@@ -227,7 +227,7 @@ variables:
 
 steps:
 - bash: |
-    sudo apt-get install ccache -y    
+    sudo apt-get install ccache -y
     echo "##vso[task.prependpath]/usr/lib/ccache"
   displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
 
@@ -235,7 +235,7 @@ steps:
   inputs:
     key: 'ccache | "$(Agent.OS)"'
     path: $(CCACHE_DIR)
-    restoreKeys: | 
+    restoreKeys: |
       ccache | "$(Agent.OS)"
   displayName: ccache
 ```
@@ -261,7 +261,7 @@ steps:
       key: 'docker | "$(Agent.OS)" | cache'
       path: $(Pipeline.Workspace)/docker
       cacheHitVar: CACHE_RESTORED                #Variable to set to 'true' when the cache is restored
-    
+
   - script: |
       docker load -i $(Pipeline.Workspace)/docker/cache.tar
     displayName: Docker restore
@@ -456,7 +456,7 @@ steps:
   displayName: Use cached Anaconda environment
   inputs:
     key: 'conda | "$(Agent.OS)" | environment.yml'
-    restoreKeys: | 
+    restoreKeys: |
       python | "$(Agent.OS)"
       python
     path: $(CONDA_CACHE_DIR)
@@ -474,12 +474,12 @@ steps:
       displayName: Cache Anaconda
       inputs:
         key: 'conda | "$(Agent.OS)" | environment.yml'
-        restoreKeys: | 
+        restoreKeys: |
           python | "$(Agent.OS)"
           python
         path: $(CONDA)/envs
         cacheHitVar: CONDA_CACHE_RESTORED
-    
+
     - script: conda env create --quiet --file environment.yml
       displayName: Create environment
       condition: eq(variables.CONDA_CACHE_RESTORED, 'false')


### PR DESCRIPTION
The caching task documentation contains a number of inaccuracies and pitfalls by being overly specific.

The Go cache example didn't cache the "correct" (expected) folder whereas the Gradle example cached entirely too much and the Maven cache was setup in a way that doesn't really mesh with "easy to use".

The examples now more closely align with [actions/cache](https://github.com/actions/cache) as documented for GitHub.