### PR TITLE
Update docker.md - replaced AGENT_MTU_VALUE with AGENT_DOCKER_MTU_VALUE

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -544,11 +544,11 @@ Now your agents will run the AKS cluster.
 
 Allow specifying MTU value for networks used by container jobs (useful for docker-in-docker scenarios in k8s cluster).
 
-You need to set the environment variable AGENT_MTU_VALUE to set the MTU value, and then restart the self-hosted agent. You can find more about agent restart [here](./windows-agent.md?#how-do-i-restart-the-agent) and about setting different environment variables for each individual agent [here](./windows-agent.md?#how-do-i-set-different-environment-variables-for-each-individual-agent).
+You need to set the environment variable AGENT_DOCKER_MTU_VALUE to set the MTU value, and then restart the self-hosted agent. You can find more about agent restart [here](./windows-agent.md?#how-do-i-restart-the-agent) and about setting different environment variables for each individual agent [here](./windows-agent.md?#how-do-i-set-different-environment-variables-for-each-individual-agent).
 
 This allows you to set up a network parameter for the job container, the use of this command is similar to the use of the next command while container network configuration:
 
-```-o com.docker.network.driver.mtu=AGENT_MTU_VALUE```
+```-o com.docker.network.driver.mtu=AGENT_DOCKER_MTU_VALUE```
 
 ## Mounting volumes using Docker within a Docker container
 


### PR DESCRIPTION
The environment variable AGENT_MTU_VALUE is incorrect. This should be AGENT_DOCKER_MTU_VALUE. See [the source code](https://github.com/microsoft/azure-pipelines-agent/blob/0b8aefd218bc7a6d39a4b406295c873c494c4857/src/Agent.Sdk/Knob/AgentKnobs.cs#L40)

In this commit the naming changed in [this commit](https://github.com/microsoft/azure-pipelines-agent/pull/3500/commits/b3d482d77479c42681767efc6e8093db3dbdb5d7). The docs were not corrected.

