### PR TITLE
Warn people so they don't waste time trying to install the agent on Ubuntu 22.04.

### DIFF
--- a/docs/pipelines/agents/linux-agent.md
+++ b/docs/pipelines/agents/linux-agent.md
@@ -49,7 +49,10 @@ We support the following subset of .NET 6 supported distributions:
     * Red Hat Enterprise Linux 7+
       * No longer requires separate package
     * SUSE Enterprise Linux 12 SP2 or later
-    * Ubuntu 22.04, 20.04, 18.04, 16.04
+    * Ubuntu 20.04, 18.04, 16.04
+      * Ubuntu 22.04 only works after manually installing version 1.1.1 of the packages `openssl` and `libssl1.1`.  
+        The script `./bin/installdependencies.sh` doesn't take care of this.  
+        Related GitHub issues: [1](https://github.com/microsoft/azure-pipelines-agent/issues/3834), [2](https://github.com/microsoft/azure-pipelines-agent/issues/4267)
     * Azure Linux 2.0
   * ARM64
     * Debian 10+


### PR DESCRIPTION
When starting a new VM, people usually choose the latest version of the distribution.
This is not a great idea for Ubuntu, since there are issues with the openssl/libssl version with Ubuntu 22.04.

-> Warn people so they better try 20.04 first.