### PR TITLE
Update conditions.md. wrong reference in describing YAML file

### DIFF
--- a/docs/pipelines/process/conditions.md
+++ b/docs/pipelines/process/conditions.md
@@ -143,7 +143,7 @@ stages:
       - script: echo 2
 ```
 
-If you queue a build on the `main` branch, and you cancel it while `stage1` is running, `stage2` *won't* run, even though it contains a job `A` whose condition evaluates to `true`. The reason is because `stage2` has the default `condition: succeeded()`, which evaluates to `false` when `stage1` is canceled. Therefore, `stage2` is skipped, and none of its jobs run.
+If you queue a build on the `main` branch, and you cancel it while `stage1` is running, `stage2` *won't* run, even though it contains a job `B` whose condition evaluates to `true`. The reason is because `stage2` has the default `condition: succeeded()`, which evaluates to `false` when `stage1` is canceled. Therefore, `stage2` is skipped, and none of its jobs run.
 
 Say you have the following YAML pipeline. Notice that, by default, `stage2` depends on `stage1` and that `script: echo 2` has a `condition` set for it.
 ```yaml


### PR DESCRIPTION
In line No. 146, while explaining the YAML file starting at line No. 129, it was mistakenly referenced as 'JOB A' while actually it has to be 'JOB B', as it was about explaining condition in job.

No condition was specified in job A