### PR TITLE
Added a note about PR iterations

### DIFF
--- a/docs/repos/git/pull-request-status.md
+++ b/docs/repos/git/pull-request-status.md
@@ -86,6 +86,11 @@ When the source branch in a PR changes, a new "iteration" is created to track th
 Services that evaluate code changes will want to post new status on each iteration of a PR. 
 Posting status to a specific iteration of a PR guarantees that status applies only to the code that was evaluated and none of the future updates. 
 
+::: moniker range=">= azure-devops-2022"
+> [!NOTE]
+> For performance and stability reasons, a PR which contains more than 100000 modified files will not support iterations. This means that iterations will not be created each time a change is made to the source PR branch. So an attempt to create a status for a non-existent iteration will return an error.
+::: moniker-end
+
 Conversely, if the status posted applies to the entire PR, independent of the code, posting to the iteration may be unnecessary. For example, checking that the author (an immutable PR property) belongs to a specific group would only need to be evaluated once, and iteration status would not be needed.
 
 When configuring the status policy, if iteration status is being used, the **Reset conditions** should be set to **Reset status whenever there are new changes**. 


### PR DESCRIPTION
Added the info to public docs that when creating a PR with more than 100k modified files ( changed, added, deleted), iteration support will be disabled for that PR. Means that the PR will not have iterations and, for example, it will not be possible to publish statuses for them ("The requested pull request status cannot be created because it is not supported for legacy pull request." error will be returned).