### PR TITLE
Add additional context for Branch Policies best practices

### DIFF
--- a/docs/repos/git/repository-settings.md
+++ b/docs/repos/git/repository-settings.md
@@ -317,6 +317,9 @@ The following table summarizes the policies you can define to customize a branch
 - Pull requests are required to update the branch.
 - The branch can't be deleted.
 
+> [!NOTE]
+> Branch policies are applied to Pull Requests based on the target branch of the Pull Request. Branch policies should not be set on temporary branches that will be deleted after a pull request. Adding branch policies to temporary branches will cause automatic branch deletion to fail.
+
 :::row:::
    :::column span="2":::
       **Policy**


### PR DESCRIPTION
Per discussions on [this](https://stackoverflow.com/questions/63372674/how-to-remove-merged-feature-branches-in-azure-devops) stackoverflow thread and [this](https://developercommunity.visualstudio.com/t/allow-to-delete-branch-after-pull-request-in-a-bra/905484) developer community post, it seems it may not be clear how branch policies are applied. Adding this short note to describe best practices when creating branch policies, especially on temporary branches.