### PR TITLE
Typo "Azure Pipeline tasks"→"Azure Pipelines tasks"

### DIFF
--- a/docs/extend/develop/work-with-urls.md
+++ b/docs/extend/develop/work-with-urls.md
@@ -49,7 +49,7 @@ Write-Host $orgUrl
 
 If this task is executed on an organization where the primary URL is the new URL form, the output is `https://dev.azure.com/{organization}`. The same task executed on an organization where the primary URL is the legacy URL form outputs `https://{organization}.visualstudio.com`.
 
-It's therefore important that Azure Pipeline tasks and services that receive events from service hooks handle both URL forms.
+It's therefore important that Azure Pipelines tasks and services that receive events from service hooks handle both URL forms.
 
 ## URLs returned in REST APIs
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/devops/extend/develop/work-with-urls?view=azure-devops&tabs=http 
https://github.com/MicrosoftDocs/azure-devops-docs/blob/main/docs/extend/develop/work-with-urls.md 
#PingMSFTDocs