### PR TITLE
Added NOTE: Service principal's token expired NOTE

### DIFF
--- a/docs/pipelines/release/azure-rm-endpoint.md
+++ b/docs/pipelines/release/azure-rm-endpoint.md
@@ -205,6 +205,9 @@ To renew the access token for an automatically created service principal:
 
 Your service principal's token has now been renewed for two more years.
 
+   > [!NOTE]
+   > This operation is available even if the service principal's token has not expired.
+
 <a name="failedToObtainJWT"></a>
 
 ### Failed to obtain the JWT by using the service principal client ID


### PR DESCRIPTION
This document describes Troubleshoot when the service principal's token has expired, but in reality, the two-year extension is available even when the service principal's token has not expired, so it is described in the Note.