### PR TITLE
Add extra information about user permissions for pushing Universal Packages

### DIFF
--- a/docs/pipelines/artifacts/universal-packages.md
+++ b/docs/pipelines/artifacts/universal-packages.md
@@ -46,7 +46,7 @@ To publish a Universal Package to your Azure Artifacts feed, add the following t
 | vstsFeedPackagePublish      | The package name. Must be lower case. Use only letters, numbers, and dashes.                                              |
 | packagePublishDescription   | Description of the package content.                                                                                       |
 
-To publish packages to an Azure Artifacts feed from your pipeline, you must add the **Project Collection Build Service** identity as a **Contributor** from your feed's settings. See [Adding users/groups permissions to a feed](../../artifacts/feeds/feed-permissions.md) for more details. Note that sometimes adding the User/Group reference **Project Collection Build Service** may not be sufficient, you may have to add **<project-name> Build Service** as a contributor, instead.
+To publish packages to an Azure Artifacts feed from your pipeline, you must add the **Project Collection Build Service** identity as a **Contributor** from your feed's settings. If you have set up your pipeline to run at project scope, you'll also need to add the project-level build identity **[Project name] Build Service ([Organization name])** as either a **Reader** or a **Contributor**. See [Adding users/groups permissions to a feed](../../artifacts/feeds/feed-permissions.md) for more details.
 
 To publish to an external feed, you must first create a service connection to authenticate with your feed. see [Manage service connection](../library/service-endpoints.md) for more details. 
 


### PR DESCRIPTION
Added a small note as for some repositories Adding just the Project Collection Build Service user will not allow some pipelines to push artifacts.