### PR TITLE
fix: Can I import updates if the source changes later

### DIFF
--- a/docs/repos/git/import-git-repository.md
+++ b/docs/repos/git/import-git-repository.md
@@ -310,7 +310,7 @@ You can sync changes using the following commands.
 We'll treat the Azure Repos import as `origin` and the original repo as `upstream`.
 
 ```shell
-git clone --bare <Azure-Repos-clone-URL>
+git clone --bare <Azure-Repos-clone-URL>.git
 cd <name-of-repo>
 git remote add --mirror=fetch upstream <original-repo-URL>
 git fetch upstream --tags


### PR DESCRIPTION
Fix the `cd` command.
With a `git clone --bare` a bare Git repository is created, wich has a `.git` postfix

https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---bare