### PR TITLE
Specify in docs that publish feed needs to use ID

### DIFF
--- a/docs/pipelines/artifacts/npm.md
+++ b/docs/pipelines/artifacts/npm.md
@@ -30,7 +30,7 @@ Using Azure Pipelines, you can publish your npm packages to Azure Artifacts feed
   inputs:
     command: publish
     publishRegistry: useFeed
-    publishFeed: <FEED_NAME>        ## For project-scoped feeds, use: <PROJECT_NAME>/<FEED_NAME> 
+    publishFeed: <FEED_ID>        ## For project-scoped feeds, use: <PROJECT_ID>/<FEED_ID> 
 ```
 
 - **publishRegistry**: Options: *useExternalRegistry*, *useFeed*.  Select *useFeed* to use a feed within your organization.


### PR DESCRIPTION
Given yaml (private info changed)
```yaml
- task: Npm@1
  displayName: 'npm publish'
  inputs:
    command: publish
    workingDir: packages/1
    verbose: false
    publishRegistry: useFeed
    publishFeed: 'Azure/PublicFeed'
```
I got an error 
```
npm ERR! 404 Not Found - PUT DOMAINandPATH/npm/registry/@ms%2fone
npm ERR! 404
npm ERR! 404 '@ms/one@1.0.0' is not in this registry.
```
Note that if I put in a nonsense value as publish feed, I did get an error that the feed didn't exist.

It only worked when I plugged in the UID from the yaml editor. So I think the requirement to use the ID should be over there in the example.