### PR TITLE
Update work-item-support-for-markdown.md to link to correct developer community thread

### DIFF
--- a/release-notes/roadmap/2023/work-item-support-for-markdown.md
+++ b/release-notes/roadmap/2023/work-item-support-for-markdown.md
@@ -14,4 +14,4 @@ hide_comments: true
 
 As a user, I want to be able to use markdown when editing long text fields (Description, Repo Steps, etc.) and the Work Item discussion. 
 
-[Community Suggestion Ticket](https://developercommunity.visualstudio.com/t/add-markdown-support-in-discussions/365826)
+[Community Suggestion Ticket](https://developercommunity.visualstudio.com/t/support-markdown-as-an-alternative-to-html-for-wor/365464)


### PR DESCRIPTION
The [original link](https://developercommunity.visualstudio.com/t/add-markdown-support-in-discussions/365826) is marked as "Completed", because **comments** on Work Items now support Markdown.

The updated community suggestion is tracking markdown support in multi-line fields (Description, etc)