### PR TITLE
being explicit about coalesce function

### DIFF
--- a/docs/pipelines/process/expressions.md
+++ b/docs/pipelines/process/expressions.md
@@ -141,7 +141,7 @@ The following built-in functions can be used in expressions.
 ::: moniker range=">= azure-devops-2019"
 
 ### coalesce
-* Evaluates the parameters in order, and returns the value that does not equal null or empty-string.
+* Evaluates the parameters in order, and returns the first value that does not equal null or empty-string.
 * Min parameters: 2. Max parameters: N
 * Example: `coalesce(variables.couldBeNull, variables.couldAlsoBeNull, 'literal so it always works')`
 


### PR DESCRIPTION
coalesce returns the first value in order that is not null or an empty string