### PR TITLE
Update security-best-practices.md

### DIFF
--- a/docs/organizations/security/security-best-practices.md
+++ b/docs/organizations/security/security-best-practices.md
@@ -77,9 +77,7 @@ The system manages permissions at different levels - individual, collection, pro
 ### Project-level permissions
 
 - Limit access to projects and repos to reduce the risk of leaking sensitive information and deploying insecure code to production.
-- Use either the built-in security groups or custom security groups to manage permissions. For more information, see [Grant or restrict permissions to select tasks](restrict-access.md) and [project-scoped user groups](about-permissions.md#project-scoped-user-group).
-- Enable the *Limit user visibility for projects* preview feature for the organization, which restricts access to only those projects that you add users to.
-- Add users to the *Project-scoped users* group, so they can only see and select users and groups in the project that they're connected to from a people picker.
+- Use either the built-in security groups or custom security groups to manage permissions. For more information, see [Grant or restrict permissions to select tasks](restrict-access.md).
 - Disable *"Allow public projects"* in your organization's policy settings to prevent every organization user from creating a public project. Azure DevOps Services allows you to change the visibility of your projects from public to private, and vice-versa. If users haven't signed into your organization, they have read-only access to your public projects. If users have signed in, they can be granted access to private projects and make any permitted changes to them.
 - Don’t allow users to create new projects.
 


### PR DESCRIPTION
Removing references to Project Scoped users since it is...
A) in preview and we have no ETA on when it'll be GA and 
B) specifically not a security feature, it only limits visibility in the UI, so we shouldn't encourage it to be used as a security feature 