### PR TITLE
Remove sudo from command example

### DIFF
--- a/docs/pipelines/agents/osx-agent.md
+++ b/docs/pipelines/agents/osx-agent.md
@@ -291,7 +291,7 @@ For example:
 ~/Library/LaunchAgents/vsts.agent.fabrikam.our-osx-agent.plist
 ```
 
-`sudo ./svc.sh install` generates this file from this template: `./bin/vsts.agent.plist.template`
+`./svc.sh install` generates this file from this template: `./bin/vsts.agent.plist.template`
 
 #### .service file
 


### PR DESCRIPTION
Using sudo will cause error "Must not run with sudo"

From svc.sh
```
# launchctl should not run as sudo for launch agents
if [ $user_id -eq 0 ]; then
    echo "Must not run with sudo"
    exit 1
fi
```