### PR TITLE
Trigger child pipeline for the same branch as the parent pipeline

### DIFF
--- a/docs/pipelines/process/pipeline-triggers.md
+++ b/docs/pipelines/process/pipeline-triggers.md
@@ -88,7 +88,8 @@ resources:
         exclude:
         - releases/old*
 ```
-To trigger the child pipeline for different branches for which the parent is triggered, include all the branch filters for which the parent is triggered. In the following example, the `app-ci` pipeline runs if the `security-lib-ci` completes on any `releases/*` branch or master branch, except for `releases/old*`.
+
+To trigger the child pipeline for different branches for which the parent is triggered, include all the branch filters for which the parent is triggered. In the following example, the `app-ci` pipeline runs if the `security-lib-ci` completes on any `releases/*` branch or main branch, except for `releases/old*`.
 
 ```yaml
 # app-ci YAML pipeline
@@ -100,7 +101,7 @@ resources:
       branches:
         include: 
         - releases/*
-        - master
+        - main
         exclude:
         - releases/old*
 ```

--- a/docs/pipelines/process/pipeline-triggers.md
+++ b/docs/pipelines/process/pipeline-triggers.md
@@ -88,7 +88,22 @@ resources:
         exclude:
         - releases/old*
 ```
+To trigger the child pipeline for different branches for which the parent is triggered, include all the branch filters for which the parent is triggered. In the following example, the `app-ci` pipeline runs if the `security-lib-ci` completes on any `releases/*` branch or master branch, except for `releases/old*`.
 
+```yaml
+# app-ci YAML pipeline
+resources:
+  pipelines:
+  - pipeline: securitylib
+    source: security-lib-ci
+    trigger: 
+      branches:
+        include: 
+        - releases/*
+        - master
+        exclude:
+        - releases/old*
+```
 > [!NOTE]
 > If your branch filters aren't working, try using the prefix `refs/heads/`. For example, use `refs/heads/releases/old*`instead of `releases/old*`.
 


### PR DESCRIPTION
Had a long running case where, when parent is triggered for different branches, the child pipeline would run only for one of the branches for which master is triggered. 

Added lines 91 to 106