### PR TITLE
Update set-variables-scripts.md

### DIFF
--- a/docs/pipelines/process/set-variables-scripts.md
+++ b/docs/pipelines/process/set-variables-scripts.md
@@ -256,7 +256,7 @@ stages:
   jobs:
   - job: B1
     variables:
-      myStageAVar: $[stageDependencies.A.A1.outputs['MyOutputVar.myStageVal']]
+      myStageAVar: $[stageDependencies.A.A1.outputs['A1.MyOutputVar.myStageVal']]
     steps:
       - bash: echo $(myStageAVar)
 ```
@@ -286,7 +286,7 @@ stages:
   jobs:
   - job: B1
     variables:
-      myStageAVar: $[stageDependencies.A.A1.outputs['MyOutputVar.myStageVal']]
+      myStageAVar: $[stageDependencies.A.A1.outputs['A1.MyOutputVar.myStageVal']]
     steps:
     - powershell: Write-Host "$(myStageAVar)"
 ```


### PR DESCRIPTION
Seems like for `stageDependencies` the syntax should be `stageDependencies.{stage name}.{job name}.outputs['{job name}.{script name}.{variable name}']`
From my tests this seems to work

But the documented one ``stageDependencies.{stage name}.{job name}.outputs['{script name}.{variable name}']`` does not seem to work

Also saw someone recommend this version ``stageDependencies.{stage name}.outputs['{job name}.{script name}.{variable name}']`` but this also doesn't seem to work

Looks like a lot of people had issues with this
[https://stackoverflow.com/questions/57485621/share-variables-across-stages-in-azure-devops-pipelines](url)
[https://github.com/microsoft/azure-pipelines-tasks/issues/4743#issuecomment-808085786](url)

Are my tests/assumptions correct? Should the docs be updated?