### PR TITLE
Correct example to match 'input' values given just above

### DIFF
--- a/docs/pipelines/process/run-number.md
+++ b/docs/pipelines/process/run-number.md
@@ -79,7 +79,7 @@ If you specify this build number format:
 $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 ```
 
-Then the second run on this day would be named: **Fabrikam\_CIBuild_master\_20190505.2**
+Then the second run on this day would be named: **Fabrikam\_CIBuild_main\_20190505.2**
 
 
 ## Tokens


### PR DESCRIPTION
It seems that the list of input values to the Example was update to have 'main' as branch name instead of 'master', but the resulting build number does not reflect this.

![image](https://github.com/MicrosoftDocs/azure-devops-docs/assets/51123426/27b26511-cc0d-421c-8404-2ff1705ebabf)
