### PR TITLE
Remove version indicator for Build Tools version download 

### DIFF
--- a/docs/pipelines/agents/windows-agent.md
+++ b/docs/pipelines/agents/windows-agent.md
@@ -40,7 +40,7 @@ Make sure your machine has these prerequisites:
 * The agent software installs its own version of .NET so there's no .NET prerequisite.
 - [PowerShell 3.0](/powershell/scripting/install/installing-windows-powershell) or higher
 * **Subversion** - If you're building from a Subversion repo, you must install the Subversion client on the machine.
-* Recommended - [Visual Studio build tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16) (2015 or higher)
+* Recommended - [Visual Studio build tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools) (2015 or higher)
 
 
 You should run agent setup manually the first time.


### PR DESCRIPTION
By removing the version indicator for the Build Tools download, the link will download the latest version