### PR TITLE
Update service-principal-managed-identity.md

### DIFF
--- a/docs/integrate/get-started/authentication/service-principal-managed-identity.md
+++ b/docs/integrate/get-started/authentication/service-principal-managed-identity.md
@@ -128,6 +128,9 @@ Service principals can be used to call Azure DevOps REST APIs and do most action
 * Service principals can't create tokens, like [personal access tokens (PATs)](../../../organizations/accounts/use-personal-access-tokens-to-authenticate.md) or [SSH Keys](../../../repos/git/use-ssh-keys-to-authenticate.md). They can generate their own Microsoft Entra ID tokens and these tokens can be used to call Azure DevOps REST APIs.
 * We don't support [Azure DevOps OAuth](./oauth.md) for service principals.
 
+> [!NOTE]
+> One can only use Application ID and not the Resource URIs associated with Azure DevOps for generting token.
+
 ## FAQs
 
 ### General

--- a/docs/integrate/get-started/authentication/service-principal-managed-identity.md
+++ b/docs/integrate/get-started/authentication/service-principal-managed-identity.md
@@ -129,7 +129,7 @@ Service principals can be used to call Azure DevOps REST APIs and do most action
 * We don't support [Azure DevOps OAuth](./oauth.md) for service principals.
 
 > [!NOTE]
-> One can only use Application ID and not the Resource URIs associated with Azure DevOps for generting token.
+> You can only use Application ID and not the Resource URIs associated with Azure DevOps for generating tokens.
 
 ## FAQs
 


### PR DESCRIPTION
MSFT Ticket response :
Ask:-
In the case o f Azure DevOps, a user can user only Application ID or we can also use urls

I checked with the product group on the ask and confirmed that in the case of ADO a user can use only Application ID, Our PG team is thinking to update the docs as well.