### PR TITLE
Missing --policy-configuration in example

### DIFF
--- a/docs/cli/policy-configuration-file.md
+++ b/docs/cli/policy-configuration-file.md
@@ -62,7 +62,7 @@ To learn more about the structure for various policy types, refer to [Policy cre
 
 ## Save the file and run the create policy command
 
-`az repos policy create C:\policyConfiguration.txt`
+`az repos policy create --policy-configuration C:\policyConfiguration.txt`
 
 Note that the path is provided using '\\' backslash.
 


### PR DESCRIPTION
In the example command the flag --policy-configuration was missing.
The cli gives 
``` 
the following arguments are required: --policy-configuration/--config
```
as response.