### PR TITLE
[Fix] Repository Variables: Undefined version variable

### DIFF
--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -496,7 +496,7 @@ variables:
   id: $[ resources.repositories.common.id ]
   type: $[ resources.repositories.common.type ]
   url: $[ resources.repositories.common.url ]
-  url: $[ resources.repositories.common.version ]
+  version: $[ resources.repositories.common.version ]
 
 steps:
 - bash: |


### PR DESCRIPTION
In the example at [repositories variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/resources?view=azure-devops&tabs=example#variables-2) the variables list currently holds no variable named `version`, which is referred to In the script below.

This PR changes one of the variable keys that are provided to version.

---

* ID: ee4ec9d0-e0d5-4fb4-7c3e-b84abfa290c2
* Version Independent ID: 3e2b80d9-30e5-0c48-49f0-4fcdfedf5eee
* Content: [Define YAML resources for Azure Pipelines - Azure Pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/resources?view=azure-devops&tabs=schema)
* Content Source: [docs/pipelines/process/resources.md](https://github.com/MicrosoftDocs/azure-devops-docs/blob/main/docs/pipelines/process/resources.md)