### PR TITLE
Updating to the correct 500 limit

### DIFF
--- a/docs/boards/github/index.md
+++ b/docs/boards/github/index.md
@@ -23,7 +23,7 @@ Stay aligned and coordinated with Azure Boards and link your code activity and i
 :::moniker range=">= azure-devops-2022"
 Azure Boards and Azure DevOps support integration with GitHub.com and GitHub Enterprise Server repositories.
 
-You can start from either Azure Boards or GitHub to integrate and connect up to 250 GitHub repositories to an Azure Boards project. 
+You can start from either Azure Boards or GitHub to integrate and connect up to 500 GitHub repositories to an Azure Boards project. 
 
 - [Install and configure the Azure Boards app for GitHub](install-github-app.md)
 - [Connect an Azure Boards project to one or more GitHub repositories](connect-to-github.md)


### PR DESCRIPTION
> Dan Hellem:
> If you are in the Azure DevOps Service, we raised the limit to 500 a few sprints back. Can you send me the links to docs? We have the info scattered all over and I probably just missed updating them all.