### PR TITLE
Update Universal package note

### DIFF
--- a/docs/artifacts/how-to/set-up-upstream-sources.md
+++ b/docs/artifacts/how-to/set-up-upstream-sources.md
@@ -70,9 +70,6 @@ With upstream sources, you can use a single feed to store the packages you gener
 
 ## Add a feed in a different organization as an upstream source
 
-> [!NOTE]
-> Universal Packages are only supported in upstream sources within the same organization.
-
 1. Select the ![gear icon](../../media/icons/gear-icon.png) button to access your feed's settings.
 
 1. Select **Upstream sources**.


### PR DESCRIPTION
Remove notes where the universal package is not supported as an upstream source for another organization. Now supported by Sprint.203.

https://learn.microsoft.com/en-us/azure/devops/release-notes/2022/artifacts/sprint-203-update
> Azure Artifacts now supports the ability to ingest Universal Packages (UPack) from other Azure DevOps organizations using upstreams.