### PR TITLE
Typo "a Azure DevOps"→"an Azure DevOps"

### DIFF
--- a/docs/report/extend-analytics/account-scoped-queries.md
+++ b/docs/report/extend-analytics/account-scoped-queries.md
@@ -57,7 +57,7 @@ In the examples provided, make the following replacements:
 
 
 > [!NOTE]
-> The remaining examples provided in this article are based on a Azure DevOps Services URL. You will need to substitute in your Azure DevOps Server URL to exercise the examples.  
+> The remaining examples provided in this article are based on an Azure DevOps Services URL. You will need to substitute in your Azure DevOps Server URL to exercise the examples.  
 
 
 <a id="work-item-count"></a>


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/devops/report/extend-analytics/account-scoped-queries?view=azure-devops&tabs=cloud 
https://github.com/MicrosoftDocs/azure-devops-docs/blob/main/docs/report/extend-analytics/account-scoped-queries.md 
#PingMSFTDocs