### PR TITLE
fix: corrects link path to security page in section "Pre-requisites" in rename-remove-team.md

### DIFF
--- a/docs/organizations/settings/rename-remove-team.md
+++ b/docs/organizations/settings/rename-remove-team.md
@@ -29,7 +29,7 @@ When you remove or delete a team, all of its configuration settings get deleted.
  
 ## Prerequisites 
 
-- To rename a team, you must be a team administrator or a member of the [**Project Administrators** group](../security/(../security/change-project-level-permissions.md)
+- To rename a team, you must be a team administrator or a member of the [**Project Administrators** group](../security/change-project-level-permissions.md)
 - To remove or delete a team, you must be a member of the **Project Administrators** group. 
 
 ## Rename a team


### PR DESCRIPTION
This PR fixes a simple typo in the "Pre-requisites" section of the rename-remove-team.md document.