### PR TITLE
Change location of imposed limits on Azure Templates

### DIFF
--- a/docs/pipelines/process/template-expressions.md
+++ b/docs/pipelines/process/template-expressions.md
@@ -328,11 +328,3 @@ jobs:
 ### Escape a value
 
 If you need to escape a value that literally contains `${{`, then wrap the value in an expression string. For example, `${{ 'my${{value' }}` or `${{ 'my${{value with a '' single quote too' }}`
-
-## Imposed limits
-
-Templates and template expressions can cause explosive growth to the size and complexity of a pipeline.
-To help prevent runaway growth, Azure Pipelines imposes the following limits:
-- No more than 100 separate YAML files may be included (directly or indirectly)
-- No more than 20 levels of template nesting (templates including other templates)
-- No more than 10 megabytes of memory consumed while parsing the YAML (in practice, this is typically between 600 KB - 2 MB of on-disk YAML, depending on the specific features used)

--- a/docs/pipelines/process/templates.md
+++ b/docs/pipelines/process/templates.md
@@ -28,6 +28,14 @@ There are two types of templates: includes and extends.
 
 To take full advantage of templates, you should also use [template expressions](template-expressions.md) and [template parameters](template-parameters.md). 
 
+### Imposed limits
+
+Templates and template expressions can cause explosive growth to the size and complexity of a pipeline.
+To help prevent runaway growth, Azure Pipelines imposes the following limits:
+- No more than 100 separate YAML files may be included (directly or indirectly)
+- No more than 20 levels of template nesting (templates including other templates)
+- No more than 10 megabytes of memory consumed while parsing the YAML (in practice, this is typically between 600 KB - 2 MB of on-disk YAML, depending on the specific features used)
+
 ::: moniker-end
 
 ::: moniker range="azure-devops-2019"


### PR DESCRIPTION
The imposed limits (specially information about max 100 YAML files) is currently located at the very end of the last page on templates can very easily be missed. Such limits can often influence design decisions for the end user (as it did for my team). This information should be available at the first page so that customers can understand their restrictions while going in to the product. 

A topic like template expressions may or may not be opened, and especially may not be scrolled to the end. 

This PR shifts the information to the main page on templates to solve this.