### PR TITLE
Fix typo in run-number.md

### DIFF
--- a/docs/pipelines/process/run-number.md
+++ b/docs/pipelines/process/run-number.md
@@ -18,7 +18,7 @@ You can customize how your pipeline runs are numbered. The default value for run
 
 In Azure DevOps `$(Rev:r)` is a special variable format that only works in the build number field. When a build is completed, if nothing else in the build number has changed, the `Rev` integer value increases by one.
 
-`$(Rev:r)` resets when you change part of the build number. For example, if you've configured your build number format as `$(BuildDefinitionName)_$(Date:yyyyMMdd)$(Rev:r)`, then the build number will reset when the date changes the next day. If your build number is `MyBuild_20230621.1`, the next build number that day is `MyBuild_20230621.2`. The next day, the build number is `MyBuild_20230622.1`.
+`$(Rev:r)` resets when you change part of the build number. For example, if you've configured your build number format as `$(Build.DefinitionName)_$(Date:yyyyMMdd)$(Rev:r)`, then the build number will reset when the date changes the next day. If your build number is `MyBuild_20230621.1`, the next build number that day is `MyBuild_20230621.2`. The next day, the build number is `MyBuild_20230622.1`.
 
 If your build number format is `1.0.$(Rev:r)`, then the build number resets to `1.0.1` when you change part of the number. For example, if your last build number was `1.0.3`, and you change the build number to `1.1.$(Rev:r)` to indicate a version change, the next build number is `1.1.1`.
 


### PR DESCRIPTION
Correct token is `$(Build.DefinitionName)`.