### PR TITLE
Update organization-name-limitation.md

### DIFF
--- a/docs/includes/organization-name-limitation.md
+++ b/docs/includes/organization-name-limitation.md
@@ -4,3 +4,7 @@ ms.topic: include
 
 > [!IMPORTANT]
 > Currently, you can only use letters from the English alphabet in your organization name. Start organization names with a letter or number, followed by letters, numbers, or hyphens. Organization names must not contain more than 50 Unicode characters and must end with a letter or number.
+>
+> In addition, some characters are not allowed in the organization name, and if any of these characters are used, the following error message will be output. If you receive this error, please select a different organization name.
+> 
+> VS850015: The specified name is not allowed to be used: {Organization name}


### PR DESCRIPTION
If the organization contains characters that cannot be used, a VS850015 error is output. Since the list of characters that cannot be used may change, it is difficult to publish a complete list, but it would be more helpful to add a note that if this error is output, you must select another organization name.

![image](https://github.com/MicrosoftDocs/azure-devops-docs/assets/65753033/607f24f7-a35d-47a6-bbd2-8fea790c6462)
