### PR TITLE
Updating tenant switch faq

### DIFF
--- a/docs/organizations/accounts/change-azure-ad-connection.md
+++ b/docs/organizations/accounts/change-azure-ad-connection.md
@@ -62,7 +62,7 @@ For more information about using Microsoft Entra ID with Azure DevOps, see the [
 
 6. Confirm that the process is complete. Sign out, and then open your browser in a private session and sign in to your organization with your Microsoft Entra ID or work credentials.
 
-7. If some members are disconnected, sign back in to Azure DevOps and map them to their Microsoft Entra identities. Or, you can invite them as guests into the Microsoft Entra ID. For more information, see the [FAQs](./faq-azure-access.yml#faq-connect).
+7. If some of your members are disconnected during this process, you will see the error message below on the Azure Active Directory page. You should be able to click the resolve button and map the disconnected users. If you run further issues, please review our [FAQ](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/faq-azure-access?view=azure-devops#some-users-are-disconnected--but-they-have-matching-identities-in-microsoft-entra-id--what-should-i-do-).
 
    :::image type="content" source="media/shared/azure-ad-select-resolve-for-disconnected-users.png" alt-text="Screenshot showing Resolve button emphasized.":::
 

--- a/docs/organizations/accounts/change-azure-ad-connection.md
+++ b/docs/organizations/accounts/change-azure-ad-connection.md
@@ -62,7 +62,7 @@ For more information about using Microsoft Entra ID with Azure DevOps, see the [
 
 6. Confirm that the process is complete. Sign out, and then open your browser in a private session and sign in to your organization with your Microsoft Entra ID or work credentials.
 
-7. If some of your members are disconnected during this process, you will see the error message below on the Azure Active Directory page. You should be able to click the resolve button and map the disconnected users. If you run further issues, please review our [FAQ](./faq-azure-access.yml#users-disconnected-after-tenant-switch).
+7. If some of your members are disconnected during this process, the following error message displays on the Microsoft Entra page. Choose **Resolve** to map the disconnected users. For more information, see the [FAQ](./faq-azure-access.yml#users-disconnected-after-tenant-switch).
 
    :::image type="content" source="media/shared/azure-ad-select-resolve-for-disconnected-users.png" alt-text="Screenshot showing Resolve button emphasized.":::
 

--- a/docs/organizations/accounts/change-azure-ad-connection.md
+++ b/docs/organizations/accounts/change-azure-ad-connection.md
@@ -62,7 +62,7 @@ For more information about using Microsoft Entra ID with Azure DevOps, see the [
 
 6. Confirm that the process is complete. Sign out, and then open your browser in a private session and sign in to your organization with your Microsoft Entra ID or work credentials.
 
-7. If some of your members are disconnected during this process, you will see the error message below on the Azure Active Directory page. You should be able to click the resolve button and map the disconnected users. If you run further issues, please review our [FAQ](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/faq-azure-access?view=azure-devops#some-users-are-disconnected--but-they-have-matching-identities-in-microsoft-entra-id--what-should-i-do-).
+7. If some of your members are disconnected during this process, you will see the error message below on the Azure Active Directory page. You should be able to click the resolve button and map the disconnected users. If you run further issues, please review our [FAQ](./faq-azure-access.yml#users-disconnected-after-tenant-switch).
 
    :::image type="content" source="media/shared/azure-ad-select-resolve-for-disconnected-users.png" alt-text="Screenshot showing Resolve button emphasized.":::
 

--- a/docs/organizations/accounts/faq-azure-access.yml
+++ b/docs/organizations/accounts/faq-azure-access.yml
@@ -415,6 +415,8 @@ sections:
           - Match the identities. Select **Next** when you're done.
           
             ![Resolve disconnected users](media/shared/resolve-disconnected-users.png)
+
+          <a name="users-disconnected-after-tenant-switch"></a>
           
       - question: |
           I got an error message when I was resolving disconnections. What should I do?


### PR DESCRIPTION
This PR intends to update the tenant switch FAQ to make it easier for the client to access relevant FAQ if they run into issues resolving users after a tenant switch