### PR TITLE
Update docker.md

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -245,7 +245,7 @@ Next, create the Dockerfile.
       ```dockerfile
       FROM ubuntu:22.04
 
-      RUN apt update -y && apt upgrade -y && apt install curl git jq libicu70
+      RUN apt update -y && apt upgrade -y && apt install curl git jq libicu70 -y
 
       # Also can be "linux-arm", "linux-arm64".
       ENV TARGETARCH="linux-x64"

--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -245,7 +245,7 @@ Next, create the Dockerfile.
       ```dockerfile
       FROM ubuntu:22.04
 
-      RUN apt update -y && apt upgrade -y && apt install curl git jq libicu72
+      RUN apt update -y && apt upgrade -y && apt install curl git jq libicu70
 
       # Also can be "linux-arm", "linux-arm64".
       ENV TARGETARCH="linux-x64"

--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -245,9 +245,7 @@ Next, create the Dockerfile.
       ```dockerfile
       FROM ubuntu:22.04
 
-      RUN apt update
-      RUN apt upgrade -y
-      RUN apt install -y curl git jq libicu70
+      RUN apt update -y && apt upgrade -y && apt install curl git jq libicu72
 
       # Also can be "linux-arm", "linux-arm64".
       ENV TARGETARCH="linux-x64"
@@ -257,8 +255,10 @@ Next, create the Dockerfile.
       COPY ./start.sh ./
       RUN chmod +x ./start.sh
 
-      RUN useradd agent
-      RUN chown agent ./
+      # Create agent user and set up home directory
+      RUN useradd -m -d /home/agent agent
+      RUN chown -R agent:agent /azp /home/agent
+
       USER agent
       # Another option is to run the agent as root.
       # ENV AGENT_ALLOW_RUNASROOT="true"


### PR DESCRIPTION
Fixes a bug that causes a permissions issue when using the Ubuntu 22.04 image. Also works with debian bookworm and bookworm slim.