### PR TITLE
Update Pipeline Caching doc to clarify s needed for checkout: self.

### DIFF
--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -98,8 +98,7 @@ When using `checkout: self`, the repository is checked out to `$(Pipeline.Worksp
 
 > [!NOTE]
 > `Pipeline.Workspace` is the local path on the agent running your pipeline where all directories are created. This variable has the same value as `Agent.BuildDirectory`.
-
-> [!NOTE]
+> 
 > Ensure you update the variable `YARN_CACHE_FOLDER` if using anything other than `checkout: self` as this should point to the repository where `.yarn` resides.
 
 #### Restore keys

--- a/docs/pipelines/release/caching.md
+++ b/docs/pipelines/release/caching.md
@@ -75,7 +75,7 @@ Here's an example showing how to cache dependencies installed by Yarn:
 
 ```yaml
 variables:
-  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/s/.yarn
 
 steps:
 - task: Cache@2
@@ -92,10 +92,15 @@ steps:
 
 In this example, the cache key contains three parts: a static string ("yarn"), the OS the job is running on since this cache is unique per operating system, and the hash of the `yarn.lock` file that uniquely identifies the set of dependencies in the cache.
 
-On the first run after the task is added, the cache step will report a "cache miss" since the cache identified by this key doesn't exist. After the last step, a cache will be created from the files in `$(Pipeline.Workspace)/.yarn` and uploaded. On the next run, the cache step will report a "cache hit" and the contents of the cache will be downloaded and restored.
+On the first run after the task is added, the cache step will report a "cache miss" since the cache identified by this key doesn't exist. After the last step, a cache will be created from the files in `$(Pipeline.Workspace)/s/.yarn` and uploaded. On the next run, the cache step will report a "cache hit" and the contents of the cache will be downloaded and restored.
+
+When using `checkout: self`, the repository is checked out to `$(Pipeline.Workspace)/s`, and your `.yarn` folder usually resides in the repository itself.
 
 > [!NOTE]
 > `Pipeline.Workspace` is the local path on the agent running your pipeline where all directories are created. This variable has the same value as `Agent.BuildDirectory`.
+
+> [!NOTE]
+> Ensure you update the variable `YARN_CACHE_FOLDER` if using anything other than `checkout: self` as this should point to the repository where `.yarn` resides.
 
 #### Restore keys
 


### PR DESCRIPTION
When running a pipeline, I believe `checkout: self` is ran by default even if not explicitly written in the pipeline. The docs stated that the `.yarn` folder variable should be equal to `$(Pipeline.Workspace)/.yarn`, this isn't correct as `checkout: self` checks out to `$(Pipeline.Workspace)/s`, so the variable should be set to `$(Pipeline.Workspace)/s/.yarn`.

Hopefully this fixes issue https://github.com/microsoft/azure-pipelines-tasks/issues/12892 so people are not unsure in the future. 

Maybe an additional point should be added about how if not using `checkout: self` (i.e. using `checkout: my-repo`) then the variable should be `$(Pipeline.Workspace)/my-repo`