### PR TITLE
Update dotnet-core.md to fix Broken Link on Publish Pipeline Artifact

### DIFF
--- a/docs/pipelines/ecosystems/dotnet-core.md
+++ b/docs/pipelines/ecosystems/dotnet-core.md
@@ -757,7 +757,7 @@ You can publish your build artifacts by:
 To publish the output of your .NET **build** to your pipeline, do the following tasks: 
 
 * Run `dotnet publish --output $(Build.ArtifactStagingDirectory)` on the .NET CLI or add the **DotNetCoreCLI@2** task with the publish command.
-* Publish the artifact by using the Publish Pipeline [Artifact task.
+* Publish the artifact by using the [Publish Pipeline Artifact](/azure/devops/pipelines/tasks/reference/publish-pipeline-artifact-v1) task.
 
 Add the following snippet to your `azure-pipelines.yml` file:
 


### PR DESCRIPTION
This is the proposed fix for issue #14029 
Page source: [Publish artifacts to Azure Pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/ecosystems/dotnet-core?view=azure-devops&tabs=yaml-editor#publish-artifacts-to-azure-pipelines)
![Screenshot 2024-02-22 162635](https://github.com/MicrosoftDocs/azure-devops-docs/assets/11170898/fa2642f1-11d4-403c-a616-a058a8c7d13a)
The misplaced square bracket indicates the **Publish Pipeline Artifact** should be a link to [PublishPipelineArtifact@1](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-pipeline-artifact-v1?view=azure-pipelines)