### PR TITLE
Fix backtick example in markdown guidance page

### DIFF
--- a/docs/project/wiki/markdown-guidance.md
+++ b/docs/project/wiki/markdown-guidance.md
@@ -193,7 +193,8 @@ Use _emphasis_ in comments to express **strong** opinions and point out <s>corre
 ## Code highlighting
 
 Highlight suggested code segments using code highlight blocks.
-To indicate a span of code, wrap it with three backtick quotes (`&#96;&#96;&#96;`) on a new line at both the start and end of the block. To indicate code inline, wrap it with one backtick quote (`&#96;`).
+To indicate a span of code, wrap it with three backtick quotes (<code>```</code>) on a new line at both the start and end of the
+block. To indicate code inline, wrap it with one backtick quote (<code>`</code>).
 
 Code highlighting entered within the Markdown widget renders code as plain preformatted text.
 


### PR DESCRIPTION
In the markdown guidance page, the example indicating code blocks and inline code display the backticks as the monospace text '&#96;'. This PR uses the HTML \<code> tag so that the backticks render properly.

Before:
![image](https://github.com/MicrosoftDocs/azure-devops-docs/assets/123992124/54090b61-bd10-4c96-bbe1-b5a9685ed8dd)

After:
![image](https://github.com/MicrosoftDocs/azure-devops-docs/assets/123992124/93c53087-364a-47e1-86c4-8b053230dd9e)
