### PR TITLE
Update URL to Wiql DevOps Extension

### DIFF
--- a/docs/boards/queries/wiql-syntax.md
+++ b/docs/boards/queries/wiql-syntax.md
@@ -52,7 +52,7 @@ ASOF '02-11-2020'
 
 
 > [!TIP] 
-> By installing the [Wiql Editor Marketplace extension](https://marketplace.visualstudio.com/items?itemName=ottostreifel.wiql-editor), you can construct your queries using the Query Editor and then view the WIQL syntax. You can then copy and modify the WIQL syntax and run the query using the **Wiql Playground** hub added to **Boards**.
+> By installing the [Wiql Editor Marketplace extension](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.wiql-editor), you can construct your queries using the Query Editor and then view the WIQL syntax. You can then copy and modify the WIQL syntax and run the query using the **Wiql Playground** hub added to **Boards**.
 
 :::row:::
    :::column span="1":::


### PR DESCRIPTION
Point it to the Microsoft DevLabs version - https://marketplace.visualstudio.com/items?itemName=ms-devlabs.wiql-editor
Instead of the no longer maintained version.