### PR TITLE
Replace --extra-index-url with --index-url in docs

### DIFF
--- a/docs/artifacts/quickstarts/python-cli.md
+++ b/docs/artifacts/quickstarts/python-cli.md
@@ -318,7 +318,7 @@ When you connect to Azure DevOps for the first time, you're prompted for credent
 
     ```
     [global]
-    extra-index-url=https://<FEED_NAME>:<YOUR_PERSONAL_ACCESS_TOKEN>@<FEED_URL>
+    index-url=https://<FEED_NAME>:<YOUR_PERSONAL_ACCESS_TOKEN>@<FEED_URL>
     ```
 
 1. To install your package, run the following command replacing \<PACKAGE_NAME\> with the package name from your feed.


### PR DESCRIPTION
Using `--extra-index-url` makes you vulnerable to dependency confusion attacks because it checks the PyPi repository for the package before it checks the custom repository. Thus it's better to use examples with `--index-url` in docs instead, to avoid users thoughtlessly copying the snippet with possible vulnerabilities.