### PR TITLE
fix encoding the token

### DIFF
--- a/docs/repos/git/includes/personal-access-tokens.md
+++ b/docs/repos/git/includes/personal-access-tokens.md
@@ -102,7 +102,7 @@ In Bash, enter the following code.
 
 ```bash
 MY_PAT=yourPAT # replace "yourPAT" with "PatStringFromWebUI"
-HEADER_VALUE=$(printf "Authorization: Basic :%s" "$MY_PAT" | base64)
+HEADER_VALUE="Authorization: Basic $(printf ":%s" "$MY_PAT" | base64)"
 
 git --config-env=http.extraheader=HEADER_VALUE clone https://dev.azure.com/yourOrgName/yourProjectName/_git/yourRepoName
 ```


### PR DESCRIPTION
Only the credentials have to be base64 encoded. The rest of the header text needs to stay in plaintext as can be seen in the powershell example. Otherwise the header will not be recognized.