### PR TITLE
Fix broken HTML in Add a dashboard widget

### DIFF
--- a/docs/extend/develop/add-dashboard-widget.md
+++ b/docs/extend/develop/add-dashboard-widget.md
@@ -107,7 +107,7 @@ Add the below HTML in `hello-world.html`. We add the mandatory reference to `VSS
 
 > Even though we are using an HTML file, most of the HTML head elements other than script and link are ignored by the framework.
 
-<a name="widget-javascript"></a>
+<a id="widget-javascript"></a>
 
 ### Step 3: Your JavaScript
 
@@ -115,16 +115,16 @@ We use JavaScript to render content in the widget. In this article, we wrap all 
 The code renders the content. This JavaScript code also initializes the VSS SDK, maps the code for your widget to your widget name, and notifies the extension framework of widget successes or failures.
 In our case, below is the code that would print &quot;Hello World&quot; in the widget. Add this `script` element in the `head` of the HTML.
 
-```html    
+```html
     <script type="text/javascript">
-        VSS.init({                        
+        VSS.init({
             explicitNotifyLoaded: true,
             usePlatformStyles: true
         });
 
         VSS.require("TFS/Dashboards/WidgetHelpers", function (WidgetHelpers) {
             WidgetHelpers.IncludeWidgetStyles();
-            VSS.register("HelloWorldWidget", function () {                
+            VSS.register("HelloWorldWidget", function () {
                 return {
                     load: function (widgetSettings) {
                         var $title = $('h2.title');
@@ -139,7 +139,7 @@ In our case, below is the code that would print &quot;Hello World&quot; in the w
     </script>
 ```
 
-<a name="vss-methods"></a>
+<a id="vss-methods"></a>
 
 `VSS.init` initializes the handshake between the iframe hosting the widget and the host frame.
 We pass `explicitNotifyLoaded: true` so that the widget can explicitly notify the host when we're done loading. This control allows us to notify load completion after ensuring that the dependent modules are loaded.
@@ -290,7 +290,7 @@ You can install or update the Cross-platform CLI for Azure DevOps (tfx-cli) usin
 ```no-highlight
 npm i -g tfx-cli
 ```
- <a name="package-the-extension"/>
+<a id="package-the-extension"></a>
 
 #### Package your extension
 
@@ -368,14 +368,14 @@ Copy the file `hello-world.html` from the previous example, and rename the copy 
 
 ```no-highlight
 |--- README.md
-|--- sdk    
-    |--- node_modules           
+|--- sdk
+    |--- node_modules
     |--- scripts
-        |--- VSS.SDK.min.js       
-|--- img                        
-    |--- logo.png                           
+        |--- VSS.SDK.min.js
+|--- img
+    |--- logo.png
 |--- scripts                        
-|--- hello-world.html               // html page to be used for your widget  
+|--- hello-world.html               // html page to be used for your widget
 |--- hello-world2.html              // renamed copy of hello-world.html
 |--- vss-extension.json             // extension's manifest
 ```
@@ -388,8 +388,8 @@ This allows the framework to uniquely identify the widget within the extension.
 ```html
 <!DOCTYPE html>
 <html>
-    <head>                          
-        <script src="sdk/scripts/VSS.SDK.min.js"></script>              
+    <head>
+        <script src="sdk/scripts/VSS.SDK.min.js"></script>
         <script type="text/javascript">
             VSS.init({
                 explicitNotifyLoaded: true,
@@ -398,7 +398,7 @@ This allows the framework to uniquely identify the widget within the extension.
 
             VSS.require("TFS/Dashboards/WidgetHelpers", function (WidgetHelpers) {
                 WidgetHelpers.IncludeWidgetStyles();
-                VSS.register("HelloWorldWidget2", function () {                
+                VSS.register("HelloWorldWidget2", function () {
                     return {
                         load: function (widgetSettings) {
                             var $title = $('h2.title');
@@ -409,7 +409,7 @@ This allows the framework to uniquely identify the widget within the extension.
                     }
                 });
                 VSS.notifyLoadSucceeded();
-            });       
+            });
         </script>
     </head>
     <body>
@@ -1084,4 +1084,3 @@ return {
 ```
 
 [Repackage](#package-the-extension) and [update](../publish/overview.md) your extension again. Refresh the dashboard that has this widget. Any changes to the widget name, in the configuration mode, update the widget title now.
-


### PR DESCRIPTION
- Update HTML anchors to use a consistent id like the others.
- Fix invalid self-closing anchor element.
- Remove some line trailing whitespace.

Issue is visible in Part 1, Step 3 on https://learn.microsoft.com/en-us/azure/devops/extend/develop/add-dashboard-widget?toc=%2Fazure%2Fdevops%2Fmarketplace-extensibility%2Ftoc.json&view=azure-devops#step-2-your-html-page---hello-worldhtml (scroll down a little).