### PR TITLE
State not required when updating existing work items using the Import Work Items tool

### DIFF
--- a/docs/boards/queries/import-work-items-from-csv.md
+++ b/docs/boards/queries/import-work-items-from-csv.md
@@ -95,7 +95,7 @@ All work items that you import get created in a *New* state. This rule means tha
 	"1047","Issue","To Do",,"Remove old test code",
 	```
 
-2. Make the edits to your work items. Your CSV file must contain the **ID**, **Work Item Type**, **Title**, and **State** fields. Any other fields you want to include are optional.
+2. Make the edits to your work items. Your CSV file must contain the **ID**, **Work Item Type**, and **Title** fields. Any other fields you want to include are optional.
 
    > [!NOTE]   
    > When you import identity fields, enter the name and email in the following format `"Display Name <email>"`. For example, to assign work to Jamal Hartnett, specify `"Jamal Hartnett <fabrikamfiber4@hotmail.com>"`. If you specify a value that isn't recognized as a valid user to the system, you may encounter problems with the import. 


### PR DESCRIPTION
State not required when updating existing work items using the Import Work Items tool. Updating the documentation to show only the required fields when updating existing work items. The fields that are required are ID, Title, and Work Item Type. This is confirmed in the screenshot below
<img width="390" alt="import" src="https://github.com/MicrosoftDocs/azure-devops-docs/assets/19974635/038350bb-0150-4c11-8c12-865803ce38aa">
