### PR TITLE
Fix syntax errors in examples for parameters in conditions

### DIFF
--- a/docs/pipelines/process/conditions.md
+++ b/docs/pipelines/process/conditions.md
@@ -285,9 +285,9 @@ jobs:
 
 When you declare a parameter in the same pipeline that you have a condition, parameter expansion happens before conditions are considered. In this case, you can embed parameters inside conditions. The script in this YAML file will run because `parameters.doThing` is true. 
 
-The `condition` in the pipeline combines two functions: `succeeded()` and `eq('${{ parameters.doThing }}', true)`. The `succeeded()` function checks if the previous step succeeded. The `succeeded()` function returns true because there was no previous step. 
+The `condition` in the pipeline combines two functions: `succeeded()` and `eq(${{ parameters.doThing }}, true)`. The `succeeded()` function checks if the previous step succeeded. The `succeeded()` function returns true because there was no previous step. 
 
-The `eq('${{ parameters.doThing }}', true)` function checks whether the doThing parameter is equal to `true`. Since the default value for doThing is true, the condition will return true by default unless a different value gets set in the pipeline. 
+The `eq(${{ parameters.doThing }}, true)` function checks whether the doThing parameter is equal to `true`. Since the default value for doThing is true, the condition will return true by default unless a different value gets set in the pipeline. 
 
 For more template parameter examples, see [Template types & usage](templates.md). 
 
@@ -300,7 +300,7 @@ parameters:
 
 steps:
 - script: echo I did a thing
-  condition: ${{ eq(parameters.doThing, true) }}
+  condition: eq(${{ parameters.doThing }}, true)
 ```
 
 
@@ -317,7 +317,7 @@ jobs:
   - job: B
     steps:
     - script: echo I did a thing
-    condition: ${{ eq(parameters.doThing, true) }}
+    condition: eq(${{ parameters.doThing }}, true)
 ```
 
 ```yaml


### PR DESCRIPTION
The change speaks for itself - a couple typos snuck in.