### PR TITLE
Update conditions.md

### DIFF
--- a/docs/pipelines/process/conditions.md
+++ b/docs/pipelines/process/conditions.md
@@ -184,7 +184,7 @@ jobs:
   dependsOn: A 
   steps:
     - script: echo step 2.1
-      condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/main', succeeded())
       
 ```
 


### PR DESCRIPTION
The example yaml under job example 2 which is supposed to show the dependency of a following stage on a primary stage is identical to example 1 where the stages are independent. The description of example 2 says it has the condition : succeeded() but this is not present in the yaml. This edit includes that condition in example 2's yaml.