### PR TITLE
Specify -t flag for ssh-keygen

### DIFF
--- a/docs/repos/git/use-ssh-keys-to-authenticate.md
+++ b/docs/repos/git/use-ssh-keys-to-authenticate.md
@@ -58,7 +58,7 @@ To use key-based authentication, you first need to generate public/private key p
 To generate key files using the RSA algorithm, run the following command from a PowerShell or another shell such as `bash` on your client:
 
 ```powershell
-ssh-keygen
+ssh-keygen -t rsa
 ```
 
 The output from the command should display the following output (where `username` is replaced by your username):


### PR DESCRIPTION
Azure DevOps requires ssh keys in RSA format, which is becoming deprecated. I just setup a new WSL instance of Ubuntu-24.04 where the default key format generated via ssh-keygen (without flags) is e25519. I think this doc. should be updated to stay current with changing distro behaviour by specifying the type now that RSA isn't guaranteed to be the default.