### PR TITLE
Agent version check document should not refer specific agent version

### DIFF
--- a/docs/pipelines/agents/includes/v2/qa-agent-version.md
+++ b/docs/pipelines/agents/includes/v2/qa-agent-version.md
@@ -7,7 +7,7 @@ author: steved0x
 ms.date: 02/12/2020
 ---
 
-### How do I make sure I have the latest v2 agent version?
+### How do I make sure I have the latest agent version?
 
 1. Navigate to the **Agent pools** tab:
 
@@ -27,7 +27,7 @@ ms.date: 02/12/2020
 
 ::: moniker range="< azure-devops"
 
-### Can I update my v2 agents that are part of an Azure DevOps Server pool?
+### Can I update my agents that are part of an Azure DevOps Server pool?
 
 Yes.
 Beginning with Azure DevOps Server 2019, you can configure your server to look for the agent package files on a local disk.


### PR DESCRIPTION
I found [this document](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/agents?view=azure-devops&tabs=yaml%2Cbrowser#faq) little confusing because it mentions v2 agent even though current mainstream agent version is v3.
v2 agent is already obsolete, so I thinks it's better to just remove v2 and make it easier to understand. The way user check agent version does not change between v2 and v3 agents.


I've noticed that this section is included from the file includes/v2/qa-agent-version.md. If the content of this FAQ does not depend on the Agent version, it might be better to save it in a directory other than the version-specific ones. Alternatively, we could create the same file in the v3 directory and rewrite the description of v2 for v3. I would appreciate it if you could consider how to best revise it.