### PR TITLE
Update azure-devops-cli-in-yaml.md

### DIFF
--- a/docs/cli/azure-devops-cli-in-yaml.md
+++ b/docs/cli/azure-devops-cli-in-yaml.md
@@ -397,15 +397,15 @@ steps:
     architecture: 'x64'
 
 # Update pip to latest
-- bash: python -m pip install --upgrade pip
+- pwsh: python -m pip install --upgrade pip
   displayName: 'Upgrade pip'
 
 # Update to latest Azure CLI version, min version required for Azure DevOps is 2.10.1
-- bash: pip install --pre azure-cli
+- pwsh: pip install --pre azure-cli
   displayName: 'Upgrade Azure CLI'
 
 # Install Azure DevOps extension
-- bash: az extension add -n azure-devops
+- pwsh: az extension add -n azure-devops
   displayName: 'Install Azure DevOps extension'
 
 # Now you can make calls into Azure DevOps CLI


### PR DESCRIPTION
The PowerShell example for "Install Azure CLI and Azure DevOps CLI extension in your pipeline" used Bash instead of PowerShell for its tasks. It is correct in the two code samples above this one, but was incorrect in the block that then combined them together into a single script.

It's a tiny change, the commands are otherwise the same, it just needs to call PowerShell for the script tasks instead of Bash.