### PR TITLE
Clarify Custom Role Definition for AzureDevopsInfrastructure Principal

### DIFF
--- a/docs/managed-devops-pools/configure-networking.md
+++ b/docs/managed-devops-pools/configure-networking.md
@@ -33,10 +33,13 @@ If you're using Express Route, you need to temporary drop or change the manageme
 > The Managed DevOps Pool and virtual network must be in the same region, or you'll get an error similar to the following when you try to create the pool or update the network configuration. `Virtual network MDPVN is in region eastus, but pool mdpnonprodsub is in region australiaeast. These must be in the same region.`
 
 Ensure the DevOpsInfrastructure principal has the following access on the virtual network:
-- Reader
-- Network Contributor, or add the following permission to a custom role: `Microsoft.Network/virtualNetworks/subnets/join/action`
-- `Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/validate/action` access using a custom role
-- `Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/write` access using a custom role
+- `Reader` and `Network Contributor`
+- OR add the following permission to a custom role:
+  - `Microsoft.Network/virtualNetworks/*/read`
+  - `Microsoft.Network/virtualNetworks/subnets/join/action`
+  - `Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/validate/action`
+  - `Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/write`
+  - `Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/delete`
 
 Make a custom role for the **Service Association Link** access. An example role can be created at the resource group or subscription level in the Access Control tab, as shown in the following example.
 


### PR DESCRIPTION
The docs are incomplete on permissions needed in a custom role, as well as being ambigious as to whether the `Reader` role is needed in addition to the custom role or not

Solve the ambiguity by including the `Microsoft.Network/virtualNetworks/*/read` action in the custom role definition, and making clear that is an alternative to the two built in roles

Added a missing permission required to delete a managed devops pool `Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/delete` action required to delete a managed devops pool