### PR TITLE
Update outdated related resource links on page Azure DevOps object limits

### DIFF
--- a/docs/organizations/settings/work/object-limits.md
+++ b/docs/organizations/settings/work/object-limits.md
@@ -256,5 +256,4 @@ For more information, see [Migrate data from Azure DevOps Server to Azure DevOps
 ## Related resources
 
 - [Tags Manager](https://marketplace.visualstudio.com/items?itemName=YodLabs.TagsManager2&ssr=false#overview)
-- [WIQL Editor](https://marketplace.visualstudio.com/items?itemName=ottostreifel.wiql-editor)
-- [Process Template Editor](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.msdevlabs-pte)
+- [WIQL Editor](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.wiql-editor)


### PR DESCRIPTION
Removed the link to Process Editor because the tool is marked as deprecated, and the tool was unlisted from Azure DevOps/Visual Studio marketplace.

Replaced the WIQL Editor Link to marketplace, because the extension is now maintained under the publisher "Microsoft DevLabs" (prev. publisher: ottostreifel).