### PR TITLE
Update variables.md to elaborate on variable syntax usage.

### DIFF
--- a/docs/pipelines/process/variables.md
+++ b/docs/pipelines/process/variables.md
@@ -146,7 +146,7 @@ Runtime expression variables are only expanded when they're used for a value, no
 
 ### What syntax should I use?
 
-Use macro syntax if you're providing a secure string or a [predefined variable](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml) input for a task. 
+Use macro syntax if you're providing a secure string or a [predefined variable](/azure/devops/pipelines/build/variables) input for a task. 
 
 Choose a runtime expression if you're working with [conditions](conditions.md) and [expressions](expressions.md). However, don't use a runtime expression if you don't want your empty variable to print (example: `$[variables.var]`). For example, if you have conditional logic that relies on a variable having a specific value or no value. In that case, you should use a macro expression. 
 

--- a/docs/pipelines/process/variables.md
+++ b/docs/pipelines/process/variables.md
@@ -146,11 +146,11 @@ Runtime expression variables are only expanded when they're used for a value, no
 
 ### What syntax should I use?
 
-Use macro syntax if you're providing input for a task. 
+Use macro syntax if you're providing a secure string or a [predefined variable](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml) input for a task. 
 
 Choose a runtime expression if you're working with [conditions](conditions.md) and [expressions](expressions.md). However, don't use a runtime expression if you don't want your empty variable to print (example: `$[variables.var]`). For example, if you have conditional logic that relies on a variable having a specific value or no value. In that case, you should use a macro expression. 
 
-If you're defining a variable in a template, use a template expression.
+Typically a template variable is the standard to use. By leveraging template variables your pipeline will fully inject the variable value into your pipeline at pipeline compilation. This is helpful when attempting to debug pipelines as one can download the log files and evalute the fully expanded value that is being substituted in. Since it is being substituted in one should not leverage template syntax for sensitive values.
 
 ## Set variables in pipeline
 

--- a/docs/pipelines/process/variables.md
+++ b/docs/pipelines/process/variables.md
@@ -150,7 +150,7 @@ Use macro syntax if you're providing a secure string or a [predefined variable](
 
 Choose a runtime expression if you're working with [conditions](conditions.md) and [expressions](expressions.md). However, don't use a runtime expression if you don't want your empty variable to print (example: `$[variables.var]`). For example, if you have conditional logic that relies on a variable having a specific value or no value. In that case, you should use a macro expression. 
 
-Typically a template variable is the standard to use. By leveraging template variables your pipeline will fully inject the variable value into your pipeline at pipeline compilation. This is helpful when attempting to debug pipelines as one can download the log files and evalute the fully expanded value that is being substituted in. Since it is being substituted in one should not leverage template syntax for sensitive values.
+Typically a template variable is the standard to use. By leveraging template variables, your pipeline will fully inject the variable value into your pipeline at pipeline compilation. This is helpful when attempting to debug pipelines. You can download the log files and evaluate the fully expanded value that is being substituted in. Since the variable is substituted in, you shouldn't leverage template syntax for sensitive values.
 
 ## Set variables in pipeline
 


### PR DESCRIPTION
This pull request includes updates to the documentation in `docs/pipelines/process/variables.md` to improve clarity on variable usage in Azure DevOps pipelines. The most important changes focus on refining the guidance for using macro and template syntax.

Documentation updates:

* Clarified that macro syntax should be used for providing secure strings or predefined variable inputs for a task.
* Expanded the explanation on template variables, emphasizing their use for fully injecting variable values at pipeline compilation and noting that template syntax should not be used for sensitive values.