### PR TITLE
Remove wrong variable reference.

### DIFF
--- a/docs/pipelines/process/deployment-jobs.md
+++ b/docs/pipelines/process/deployment-jobs.md
@@ -499,7 +499,6 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'
     variables:
-      myVarFromDeploymentJob: $[ dependencies.A2.outputs['A2.setvarStepTwo.myOutputVar'] ]
       myOutputVarTwo: $[ dependencies.A2.outputs['Deploy_vmsfortesting.setvarStepTwo.myOutputVarTwo'] ]
     
     steps:


### PR DESCRIPTION
Job B2 references a Deployment A1 variables, with a wrong variable reference syntax.

This:
`myVarFromDeploymentJob: $[ dependencies.A2.outputs['A2.setvarStepTwo.myOutputVar'] ]
`
Should be: 
`myVarFromDeploymentJob: $[ dependencies.A1.outputs['A1.setvarStep.myOutputVar'] ]
`

But in my opinion, the variables reference can be removed for job B2, because it is unused and misleading.