### PR TITLE
Small fix for Event ID description

### DIFF
--- a/docs/service-hooks/events.md
+++ b/docs/service-hooks/events.md
@@ -2385,7 +2385,7 @@ Event: A pull request is updated; status, review list, reviewer vote changed, or
 Event: A pull request is commented on.
 
 * Publisher ID: `azure-devops`
-* Event ID: `git-pullrequest-comment-event`
+* Event ID: `ms.vss-code.git-pullrequest-comment-event`
 * Resource Name: `pullrequest`
 
 #### Settings


### PR DESCRIPTION
The sample event payload was showing the event type correctly, however the documentation been missing the "ms.vss-code." prefix which however had been present with other events.