### PR TITLE
support authenticating with a service principal in Linux

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -227,9 +227,9 @@ Next, create the Dockerfile.
       # FROM arm64v8/alpine
       # ENV TARGETARCH="linux-musl-arm64"
 
-      RUN apk update
-      RUN apk upgrade
-      RUN apk add bash curl gcc git icu-libs jq musl-dev python3-dev libffi-dev openssl-dev cargo make
+      RUN apk update && \
+        apk upgrade && \
+        apk add bash curl gcc git icu-libs jq musl-dev python3-dev libffi-dev openssl-dev cargo make
 
       # Install Azure CLI
       RUN pip install --upgrade pip
@@ -255,9 +255,9 @@ Next, create the Dockerfile.
       ENV TARGETARCH="linux-x64"
       # Also can be "linux-arm", "linux-arm64".
 
-      RUN apt update
-      RUN apt upgrade -y
-      RUN apt install -y curl git jq libicu70
+      RUN apt update && \
+        apt upgrade -y && \
+        apt install -y curl git jq libicu70
 
       # Install Azure CLI
       RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash

--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -378,6 +378,7 @@ Next, create the Dockerfile.
 
     print_header "3. Configuring Azure Pipelines agent..."
 
+    # Despite it saying "PAT", it can be the token through the service principal
     ./config.sh --unattended \
       --agent "${AZP_AGENT_NAME:-$(hostname)}" \
       --url "${AZP_URL}" \


### PR DESCRIPTION
It appears issues got turned off in this repository, but I had described the background in [#13864](https://github.com/MicrosoftDocs/azure-devops-docs/issues/13864#issuecomment-1928675057): I was trying to set up a Pipeline agent in a Docker container on Linux using a service principal, and it wasn't clear how to authenticate.

This pull request updates the instructions and code for Linux to support authentication with a service principal, which I was able to do locally. I don't know Powershell so I didn't touch that part of the page, but it should be possible there too.

Thanks!