### PR TITLE
Update personal-access-tokens.md

### DIFF
--- a/docs/repos/git/includes/personal-access-tokens.md
+++ b/docs/repos/git/includes/personal-access-tokens.md
@@ -105,7 +105,7 @@ In Bash, enter the following code.
 MY_PAT=yourPAT # replace "yourPAT" with "PatStringFromWebUI"
 export HEADER_VALUE=$(echo -n "Authorization: Basic " $(printf ":%s" "$MY_PAT" | base64))
 
-git --config-env=http.extraheader=$HEADER_VALUE clone https://dev.azure.com/yourOrgName/yourProjectName/_git/yourRepoName
+git --config-env=http.extraheader=HEADER_VALUE clone https://dev.azure.com/yourOrgName/yourProjectName/_git/yourRepoName
 ```
 
 To keep your token more secure, use credential managers so you don't have to enter your credentials every time. We recommend [Git Credential Manager](https://github.com/GitCredentialManager/git-credential-manager).


### PR DESCRIPTION
`git --config-env` requires the name of an environment variable, not bash variable expansion.   
As currently written, the doc's command does not work in ubuntu 22.04 with git 2.34.1.

See [git --config-env option](https://git-scm.com/docs/git#Documentation/git.txt---config-envltnamegtltenvvargt)