### PR TITLE
[Minor spelling issue] Fixed casing

### DIFF
--- a/release-notes/roadmap/2024/ghazdo/secret-validity.md
+++ b/release-notes/roadmap/2024/ghazdo/secret-validity.md
@@ -12,6 +12,6 @@ hide_comments: true
 
 # Advanced Security shows the results of validity checking for supported secret types
 
-As with on Github, Advanced Security will be able to produce validity data for selected partner tokens. 
+As with on GitHub, Advanced Security will be able to produce validity data for selected partner tokens. 
 
 Validity checks determine whether a token is still active and, when possible, whether it was ever active. This is useful when you’re deciding how to remediate an exposure. For example, you might prioritize remediating active secrets before checking your security logs for unauthorized access via API keys that have already been revoked.


### PR DESCRIPTION
Changed casing: `Github` -> `GitHub`