### PR TITLE
Update personal-access-tokens.md

### DIFF
--- a/docs/repos/git/includes/personal-access-tokens.md
+++ b/docs/repos/git/includes/personal-access-tokens.md
@@ -103,9 +103,9 @@ In Bash, enter the following code.
 
 ```bash
 MY_PAT=yourPAT # replace "yourPAT" with "PatStringFromWebUI"
-export HEADER_VALUE=$(echo -n "Authorization: Basic " $(printf ":%s" "$MY_PAT" | base64))
+export HEADER_VALUE=$(echo -n "Authorization: Basic "$(printf ":%s" "$MY_PAT" | base64))
 
-git --config-env=http.extraheader=$HEADER_VALUE clone https://dev.azure.com/yourOrgName/yourProjectName/_git/yourRepoName
+git --config-env=http.extraheader=HEADER_VALUE clone https://dev.azure.com/yourOrgName/yourProjectName/_git/yourRepoName
 ```
 
 To keep your token more secure, use credential managers so you don't have to enter your credentials every time. We recommend [Git Credential Manager](https://github.com/GitCredentialManager/git-credential-manager).


### PR DESCRIPTION
bug in Use a PAT token Linux/macOS documentation:
fatal: missing environment variable...
fix:
change in git clone command: $HEADER_VALUE -> HEADER_VALUE according to: https://git-scm.com/docs/git/2.34.0
in addition:
unnecessary double space between Basic and PAT token