### PR TITLE
Small Spelling fix

### DIFF
--- a/docs/pipelines/process/includes/secret-variables-logging.md
+++ b/docs/pipelines/process/includes/secret-variables-logging.md
@@ -9,7 +9,7 @@ ms.date: 05/31/2022
 
 When `issecret` is set to true, the value of the variable will be saved as secret and masked out from logs.
 
-[!INCLUDE [secrests masked](./masked-secrets.md)]
+[!INCLUDE [secrets masked](./masked-secrets.md)]
 
 # [Bash](#tab/bash)
 


### PR DESCRIPTION
Didn't manage to find more at my yearly documentation fixing spree across multiple doc projects.
Great to see ADO docs in a far superior position to azure-docs, sql-docs, pwsh-docs and more.

I did find some spelling issues that also require image name changes but i didnt know if you accept those.
Are you accepting those as well ?