### PR TITLE
Fixed casing of "GitHub"

### DIFF
--- a/release-notes/roadmap/2024/boards-ghec-data-residency-support.md
+++ b/release-notes/roadmap/2024/boards-ghec-data-residency-support.md
@@ -1,16 +1,16 @@
 ---
-title: Support for Github Enterprise Cloud with data residency
+title: Support for GitHub Enterprise Cloud with data residency
 author: danhellem
 ms.author: dahellem
 ms.date: 10/22/2024
 ms.topic: article
 ms.service: azure-devops
 ms.subservice: azure-devops-release-notes
-description: Support for Github Enterprise Cloud with data residency
+description: Support for GitHub Enterprise Cloud with data residency
 hide_comments: true
 ---
 
-# Support for Github Enterprise Cloud with data residency
+# Support for GitHub Enterprise Cloud with data residency
 
 Support GitHub integration with Azure Boards and Azure Pipelines for customers who are using GitHub Enterprise Cloud with data residency.
 


### PR DESCRIPTION
Changes:

- [x] `Github `-> `GitHub`