### PR TITLE
fix sample task DependencyScanning timeout

### DIFF
--- a/docs/repos/security/github-advanced-security-dependency-scanning-troubleshoot.md
+++ b/docs/repos/security/github-advanced-security-dependency-scanning-troubleshoot.md
@@ -58,7 +58,7 @@ To use this variable, add `DependencyScanning.Timeout` as a pipeline variable:
 >[!div class="tabbedCodeSnippets"]
 ```yaml
 - task: AdvancedSecurity-Dependency-Scanning@1
-- env:
+  env:
     DependencyScanning.Timeout: 600
 ```
 


### PR DESCRIPTION
Fix the yaml syntax for Azure Pipelines of the code sample of the task `AdvancedSecurity-Dependency-Scanning@1` setting the (environment) variable `DependencyScanning.Timeout`