### PR TITLE
Update webhooks.md

### DIFF
--- a/docs/service-hooks/services/webhooks.md
+++ b/docs/service-hooks/services/webhooks.md
@@ -26,7 +26,8 @@ You need the following prerequisites to manage webhooks for an Azure DevOps orga
 
   >[!IMPORTANT]
   >It's recommended to use only HTTPS endpoints. HTTP has the potential to send private data, including authentication headers, unencrypted in the event payload. You must use HTTPS for basic authentication on a webhook.
-
+- If connecting to a service behind a virtual private network, ensure that Azure DevOps IP addresses are allowed for inbound connections. See [Inbound Connections](../../organizations/security/allow-list-ip-url.md).
+  
 ## Send JSON representation to a service
 
 1. In your Azure DevOps project, go to **Project settings** > **Service hooks** at `https://<organization-name>/<project-name>/_settings/serviceHooks`.


### PR DESCRIPTION
Documentation for "Allowed IP addresses and domain URLs", has the ADO IPs to be allow listed when connecting to Service Hooks. 

But the Service Hooks documentation link has example with only Public service and customers are creating cases requesting a way to connect to a service behind a private network. 

Added the documentation link which specifies the ADO IPs to be allow listed to connect to Services:

https://learn.microsoft.com/en-us/azure/devops/organizations/security/allow-list-ip-url?view=azure-devops&tabs=IP-V4#inbound-connections