### PR TITLE
Update YAML parsing limits value

### DIFF
--- a/docs/pipelines/process/templates.md
+++ b/docs/pipelines/process/templates.md
@@ -33,8 +33,8 @@ To take full advantage of templates, you should also use [template expressions](
 Templates and template expressions can cause explosive growth to the size and complexity of a pipeline.
 To help prevent runaway growth, Azure Pipelines imposes the following limits:
 - No more than 100 separate YAML files may be included (directly or indirectly)
-- No more than 20 levels of template nesting (templates including other templates)
-- No more than 10 megabytes of memory consumed while parsing the YAML (in practice, this is typically between 600 KB - 2 MB of on-disk YAML, depending on the specific features used)
+- No more than 100 levels of template nesting (templates including other templates)
+- No more than 20 megabytes of memory consumed while parsing the YAML (in practice, this is typically between 600 KB - 2 MB of on-disk YAML, depending on the specific features used)
 
 ::: moniker-end
 


### PR DESCRIPTION
The docs are outdated on two places when it comes to limits we impose on YAML during parsing. We allow 100 levels of template nesting (docs state 20) Allowed memory consumption is 20 megabytes (docs state 10)