### PR TITLE
Update scheduled-triggers.md

### DIFF
--- a/docs/pipelines/process/scheduled-triggers.md
+++ b/docs/pipelines/process/scheduled-triggers.md
@@ -52,7 +52,7 @@ schedules:
   branches:
     include: [ string ] # which branches the schedule applies to
     exclude: [ string ] # which branches to exclude from the schedule
-  always: boolean # whether to always run the pipeline or only if there have been source code changes since the last successful scheduled run. The default is false.
+  always: boolean # whether to always run the pipeline or only if there have been source code or pipeline settings changes since the last successful scheduled run. The default is false.
 ```
 
 ::: moniker-end
@@ -66,7 +66,7 @@ schedules:
   branches:
     include: [ string ] # which branches the schedule applies to
     exclude: [ string ] # which branches to exclude from the schedule
-  always: boolean # whether to always run the pipeline or only if there have been source code changes since the last successful scheduled run. The default is false.
+  always: boolean # whether to always run the pipeline or only if there have been source code or pipeline settings changes since the last successful scheduled run. The default is false.
   batch: boolean # Whether to run the pipeline if the previously scheduled run is in-progress; the default is false.
   # batch is available in Azure DevOps Server 2022.1 and higher
 ```


### PR DESCRIPTION
Fix public docs about schedule triggers with always flag. Currently public doc says that the always flag means that schedule builds should be queued only if there are code changes, which is not true. Changes to the pipeline will also cause schedule trigger to be queued.