### PR TITLE
Add note about AKS user authentication expiration scenario in service-endpoints.md

### DIFF
--- a/docs/pipelines/library/service-endpoints.md
+++ b/docs/pipelines/library/service-endpoints.md
@@ -507,7 +507,7 @@ Use the following parameters when you define a connection to a Kubernetes cluste
 
 > [!NOTE]
 > User certificates issued by Azure Kubernetes Service are valid for two years. If you choose to use kubeconfig, you will need to reconfigure service connections after two years.
-> To get user certificate issued by Azure Kubernetes Service from current context, use the command: `kubectl config view --raw -o jsonpath="{.users[?(@.name contains clusterUser_.*_$(kubectl config current-context))].user.client-certificate-data}"`
+> To get user certificate issued by Azure Kubernetes Service from current context, use the command: `kubectl config view --raw -o jsonpath="{.users[?(@.name contains clusterUser_.*_$(kubectl config current-context))].user.client-certificate-data}" | base64 -d`
 > To check when user certificate will expire, use the command: `cat <cert_file> | openssl x509 -enddate -noout -in -`
 
 #### Service account option

--- a/docs/pipelines/library/service-endpoints.md
+++ b/docs/pipelines/library/service-endpoints.md
@@ -507,7 +507,7 @@ Use the following parameters when you define a connection to a Kubernetes cluste
 
 > [!NOTE]
 > User certificates issued by Azure Kubernetes Service are valid for two years. If you choose to use kubeconfig, you will need to reconfigure service connections after two years.
-> To get user certificate issued by Azure Kubernetes Service, use the command: `kubectl config view --raw -o jsonpath="{.users[?(@.name contains clusterUser_.*_$(kubectl config current-context))].user.client-certificate-data}"`
+> To get user certificate issued by Azure Kubernetes Service from current context, use the command: `kubectl config view --raw -o jsonpath="{.users[?(@.name contains clusterUser_.*_$(kubectl config current-context))].user.client-certificate-data}"`
 > To check when user certificate will expire, use the command: `cat <cert_file> | openssl x509 -enddate -noout -in -`
 
 #### Service account option

--- a/docs/pipelines/library/service-endpoints.md
+++ b/docs/pipelines/library/service-endpoints.md
@@ -505,6 +505,10 @@ Use the following parameters when you define a connection to a Kubernetes cluste
 | Description | Optional. The description of the service connection. |
 | Security | Optional. Select **Grant access permission to all pipelines** to allow all pipelines to use this connection. If you don't select this option, you must explicitly authorize the service connection for each pipeline that uses it. |
 
+> [!NOTE]
+> User certificates issued by Azure Kubernetes Service are valid for two years. If you choose to use kubeconfig, you will need to reconfigure service connections after two years.
+> To get user certificate issued by Azure Kubernetes Service, use the command: `kubectl config view --raw -o jsonpath="{.users[?(@.name contains clusterUser_.*_$(kubectl config current-context))].user.client-certificate-data}"`
+> To check when user certificate will expire, use the command: `cat <cert_file> | openssl x509 -enddate -noout -in -`
 
 #### Service account option
 


### PR DESCRIPTION
**Proposed change:** Add note to tell user to take case about the certification expiration scenario with how-to

**Supporting point:**
- Ran into a scenario where after 2 years my DevOps pipeline was not deploying to AKS. I thought we should add this note to alert users.
- Checking user certificate generated by AKS: it is two years
```
joey [ ~ ]$ cat test.pem | openssl x509 -startdate -enddate -noout -in -
notBefore=Jan 23 05:33:49 2025 GMT
notAfter=Jan 23 05:43:49 2027 GMT
```

```
kubectl config view --raw -o jsonpath="{.users[?(@.name contains clusterUser_.*_$(kubectl config current-context))].user.client-certificate-data}" | base64 -d | openssl x509 -enddate -noout -in -
notAfter=Jan 23 05:43:49 2027 GMT
```
