### PR TITLE
Fix typo: Missing bold syntax in navigation/index.md

### DIFF
--- a/docs/project/navigation/index.md
+++ b/docs/project/navigation/index.md
@@ -60,7 +60,7 @@ Here's what you need to know to get up and running using the web portal.
 
 
 ::: moniker range=">= azure-devops-2019"  
-You select services—such as **Boards**, **Repos**, and **Pipelines—from the sidebar and pages within those services. 
+You select services—such as **Boards**, **Repos**, and **Pipelines**—from the sidebar and pages within those services. 
 
 ![Vertical sidebar](media/gif-images/vertical-nav.gif)
 


### PR DESCRIPTION
The double-asterisk syntax around a single word needed a closing pair of asterisks to render the word as bold