### PR TITLE
Update for macOS-latest.md

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -61,7 +61,7 @@ You can see the installed software for each hosted agent by choosing the **Inclu
 * [The Ubuntu 18.04 image will begin deprecation on 8/8/22 and will be fully unsupported by 4/1/2023](https://github.com/actions/runner-images/issues/6002).
 * [The macOS 10.15 image will begin deprecation on 5/31/22 and will be fully unsupported by 12/1/2022](https://github.com/actions/runner-images/issues/5583).
 * [`windows-latest` images use `windows-2022`](https://github.com/actions/runner-images/issues/4856).
-* [`macOS-latest` images use `macOS-11`](https://github.com/actions/runner-images/issues/4060).
+* [`macOS-latest` images use `macOS-14`](https://devblogs.microsoft.com/devops/upcoming-deprecation-of-macos-12-hosted-pipeline-image/).
 * [The Ubuntu 16.04 hosted image was removed September 2021](https://github.com/actions/runner-images/issues/3287).
 * The Windows Server 2016 with Visual Studio 2017 image is deprecated and was retired June 30 2022. Read [this blog post](https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/#windows) on how to identify pipelines using deprecated images.
 * In December 2021, we removed the following Azure Pipelines hosted image:


### PR DESCRIPTION
The doc still points to macOS-11 for macOS-latest. macOS-12 is also deprecated. macOS-latest points to macOS-14.