### PR TITLE
attempting to fix unclosed anchor tag

### DIFF
--- a/docs/boards/queries/linking-attachments.md
+++ b/docs/boards/queries/linking-attachments.md
@@ -191,7 +191,7 @@ The following table describes fields associated with links and attachments. Most
 :::row-end:::
 :::row:::
    :::column span="1":::
-   <a id="external-link-count"/>
+   <a id="external-link-count"></a>
 
    **External Link Count**
 
@@ -203,7 +203,7 @@ The following table describes fields associated with links and attachments. Most
 :::row-end:::
 :::row:::
    :::column span="1":::
-   <a id="hyper-link-count"/>
+   <a id="hyper-link-count"></a>
 
    **Hyperlink Count**
 
@@ -239,7 +239,7 @@ The following table describes fields associated with links and attachments. Most
 ::: moniker range=">= azure-devops-2022" 
 :::row:::
    :::column span="1":::
-   <a id="parent"/>
+   <a id="parent"></a>
 
    **Parent**
 
@@ -258,7 +258,7 @@ The following table describes fields associated with links and attachments. Most
 ::: moniker range="azure-devops-2020" 
 :::row:::
    :::column span="1":::
-   <a id="parent"/>
+   <a id="parent"></a>
 
    **Parent**
 
@@ -273,7 +273,7 @@ The following table describes fields associated with links and attachments. Most
 ::: moniker-end 
 :::row:::
    :::column span="1":::
-   <a id="related-link-count"/>
+   <a id="related-link-count"></a>
 
    **Related Link Count**
 
@@ -285,7 +285,7 @@ The following table describes fields associated with links and attachments. Most
 :::row-end:::
 :::row:::
    :::column span="1":::
-   <a id="remote-link-count"/>
+   <a id="remote-link-count"></a>
 
    **Remote Link Count**
 


### PR DESCRIPTION
On the rendered page, in the table under "Fields associated with links and attachments", everything in between "External Link Count" and "Remote Link Count" is treated as if it were a giant link. The link doesn't close until it hits some Markdown link syntax within the second column on the row, "Remote Link Count". This seems to be caused by the self-closing anchor tag near "External Link Count" not actually closing, but it's kind of hard to tell without seeing a preview build.

![image](https://github.com/user-attachments/assets/6a34809e-73aa-4b90-9927-c21eed11f43c)
