### PR TITLE
Update github-advanced-security-code-scanning.md to remove mention of Autobuild task

### DIFF
--- a/docs/repos/security/github-advanced-security-code-scanning.md
+++ b/docs/repos/security/github-advanced-security-code-scanning.md
@@ -61,8 +61,6 @@ Code scanning supports two build modes when setting up a pipeline for scanning:
 
 For more information on the different build modes including a comparison on the benefits of each build mode, see [CodeQL code scanning for compiled languages](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages#about-the-codeql-analysis-workflow-and-compiled-languages). 
 
-For running code scanning analysis through GitHub Advanced Security for Azure DevOps, the `autobuild` build mode is instead a separate build task, [`AdvancedSecurity-CodeQL-Autobuild@1`](/azure/devops/pipelines/tasks/reference/advanced-security-codeql-autobuild-v1).
-
 > [!TIP]
 > Build mode `none` is useable with other interpreted languages, for example, JavaScript, Python, Ruby.
 > If build mode `none` is specified for C# or Java with other compiled languages that don't support build mode `none`, the pipeline task fails.


### PR DESCRIPTION
Removed "For running code scanning analysis through GitHub Advanced Security for Azure DevOps, the `autobuild` build mode is instead a separate build task, [`AdvancedSecurity-CodeQL-Autobuild@1`](/azure/devops/pipelines/tasks/reference/advanced-security-codeql-autobuild-v1)."