### PR TITLE
python-webapp.md: fix missing package

### DIFF
--- a/docs/pipelines/ecosystems/python-webapp.md
+++ b/docs/pipelines/ecosystems/python-webapp.md
@@ -563,7 +563,7 @@ stages:
         python -m venv antenv
         source antenv/bin/activate
         python -m pip install --upgrade pip
-        pip install setup
+        pip install setuptools
         pip install -r requirements.txt
       workingDirectory: $(projectRoot)
       displayName: "Install requirements"
@@ -727,7 +727,7 @@ The job contains multiple steps:
            python -m venv antenv
            source antenv/bin/activate
            python -m pip install --upgrade pip
-           pip install setup
+           pip install setuptools
            pip install  -r ./requirements.txt
          workingDirectory: $(projectRoot)
          displayName: "Install requirements"


### PR DESCRIPTION
The `setup` package has no relevance here, and is being parked: https://pypi.org/project/setup/. This is a potential supply chain attack.

I've made the guess that the original author was trying to install setuptools, which is also found later in the document in "Run tests on the build agent"