### PR TITLE
Fix "\" in markdown with

### DIFF
--- a/release-notes/2025/includes/pipelines/sprint-248-update.md
+++ b/release-notes/2025/includes/pipelines/sprint-248-update.md
@@ -70,6 +70,6 @@ In the `approvers` property, you can use the following values (comma separated) 
 * Email address,
 * Permission-Group,
 * Project-Team,
-* [ProjectName]\[Permission Group],
-* [Org]\[Permission Group],
-* [ProjectName]\[Project Team]
+* [ProjectName]\\[Permission Group],
+* [Org]\\[Permission Group],
+* [ProjectName]\\[Project Team]


### PR DESCRIPTION
Very confusing when this does not render the `\` in the documentation