### PR TITLE
Clarify how 'private' extensions work

### DIFF
--- a/docs/extend/develop/manifest.md
+++ b/docs/extend/develop/manifest.md
@@ -53,7 +53,7 @@ For information about inputs, see [...](custom-control.md)
 
 #### Mark an extension public
 
-By default, all extensions in the [Azure DevOps Marketplace](https://marketplace.visualstudio.com/azuredevops/) are private. They're only visible to the publisher and accounts shared to by the publisher. If your publisher is verified, you can make your extension public by setting the `Public` flag in your extension manifest:
+By default, all extensions in the [Azure DevOps Marketplace](https://marketplace.visualstudio.com/azuredevops/) are private. They are hidden from public view, and are only visible to the publisher and specific accounts shared to by the publisher. If your publisher is verified, you can make your extension public by setting the `Public` flag in your extension manifest:
 
 ```json
 {

--- a/docs/extend/includes/procedures/publish.md
+++ b/docs/extend/includes/procedures/publish.md
@@ -14,7 +14,7 @@ Once your extension is packaged, you can upload it to the Marketplace under a pu
 
     :::image type="content" source="../../get-started/media/published-extension.png" alt-text="Screenshot showing extension in the list of published extensions."::: 
 
-At this point, your extension isn't visible to any accounts and can't be installed until you share it.
+At this point, your extension isn't visible to any accounts. To make it visible to others, you need to share the extension.
 
 > [!NOTE]
 > Microsoft runs a virus scan on each new and updated extension package published. Until the scan is all clear, we don't publish the extension in the Marketplace for public usage. This way we also avoid surfacing inappropriate or offensive content on the Marketplace pages.

--- a/docs/extend/overview.md
+++ b/docs/extend/overview.md
@@ -17,7 +17,7 @@ ms.date: 03/21/2025
 
 Extensions are add-ons that you can use to customize and extend your experience with Azure DevOps. They're written using standard technologies such as HTML, JavaScript, and CSS, and can be developed using your preferred development tools.
 
-Extensions are published on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/azuredevops), where they can be kept private for you and your team or [shared publicly](publish/publicize.md) with millions of developers currently using Azure DevOps.
+Extensions are published on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/azuredevops), where they can be kept private for you and your team or [shared publicly](./publish/overview.md) with millions of developers currently using Azure DevOps.
 
 Extensions use our [RESTful API Library](/rest/api/azure/devops/) to easily interact with Azure DevOps and other applications/services.
 
@@ -123,7 +123,7 @@ For more information about building extensions, see the following articles:
 - [Service Hooks](../service-hooks/overview.md)
 - [Package, publish, and install your extension](./publish/overview.md)
 - [Package and publish your integration with an external app or service](./publish/integration.md)
-- [Share your work publicly with the entire community](./publish/publicize.md)
+- [Share your work publicly with the entire community](./develop/manifest.md#mark-an-extension-public)
  
 ## Next steps
 

--- a/docs/extend/publish/overview.md
+++ b/docs/extend/publish/overview.md
@@ -147,7 +147,9 @@ After you change the manifest, deploy and install this debugging extension only 
 
 ## Make your extension public
 
-While you develop your extension or integration for the Marketplace, keep it private. To make your extension available publicly, set the [public flag](../develop/manifest.md#public-flag) to `true` in your manifest.
+While you develop your extension or integration for the Marketplace, keep it private. This limits the visibility of the extension to specific accounts that you have shared it with.
+
+To make your extension available publicly, set the [public flag](../develop/manifest.md#public-flag) to `true` in your manifest.
 
 ### Qualifications
 


### PR DESCRIPTION
Following on from a discussion with @panagiotisliaros, we decided to update the documentation around private extensions to clarify how they work, and what the 'private' setting does. For this, I made changes to:

- `docs/extend/develop/manifest.md`
- `docs/extend/includes/procedures/publish.md`
- `docs/extend/publish/overview.md`

I also updated some links in `docs/extend/overview.md` to point to more appropriate locations.

Please let me know if you have any questions or feedback.