### PR TITLE
Drop CBL Mariner 2.0 support for 3.x agents

### DIFF
--- a/docs/pipelines/agents/v3-agent.md
+++ b/docs/pipelines/agents/v3-agent.md
@@ -38,7 +38,6 @@ The following operating systems are supported by the 3.x agent.
       * No longer requires separate package
     * SUSE Enterprise Linux 12 SP2 or later
     * Ubuntu 22.04, 20.04, 18.04, 16.04
-    * Azure Linux 2.0
     * Oracle Linux 7 and higher
   * ARM64
     * Debian 10+


### PR DESCRIPTION
**Description**: Drop CBL Mariner 2.0 support for 3.x agents as [the distro is outdated](https://techcommunity.microsoft.com/blog/azuretoolsblog/announcement-of-migrating-to-azure-linux-3-0-for-azure-cli/4419582#:~:text=Azure%20Linux%202.0%20will%20reach%20its%20End%20of%20Life%20(EOL)%20on%20July%202025)