### PR TITLE
Added Ubuntu 24.04 image version

### DIFF
--- a/docs/pipelines/agents/linux-agent.md
+++ b/docs/pipelines/agents/linux-agent.md
@@ -50,7 +50,7 @@ We support the following subset of .NET 6 supported distributions:
     * Red Hat Enterprise Linux 7+
       * No longer requires separate package
     * SUSE Enterprise Linux 12 SP2 or later
-    * Ubuntu 22.04, 20.04, 18.04, 16.04
+    * Ubuntu 24.04, 22.04, 20.04, 18.04, 16.04
     * Azure Linux 2.0
     * Oracle Linux 7 and higher
   * ARM64


### PR DESCRIPTION
We have updated MS hosted agents to support Ubuntu 24.04.  Our documentation does not reflect this change for self-hosted agents. If our agent can run successfully on MS Hosted Ubuntu 24.04 VM, then it would be able to run on self-hosted agent. Currently we get agent version '4.258.1' with Ubuntu-24.04 MS hosted agent.