### PR TITLE
Update navigate-test-plans.md

### DIFF
--- a/docs/test/navigate-test-plans.md
+++ b/docs/test/navigate-test-plans.md
@@ -208,7 +208,7 @@ Choose **Copy test case** to copy or clone a test case. Specify the destination 
 
 Use **View linked items** option, to review objects linked to the test case. Choose each tab to view the links listed under the linked object type: 
 - **Test Suites**
-- **Requirements**: Includes any work item that belongs to the Requirements Category, such as User Stories (Agile), Product Backlog Items (Scrum), Requirements (CMMI), or a custom work item type.
+- **Requirements**: Includes any work item that belongs to the Requirements Category, such as User Stories (Agile), Product Backlog Items (Scrum), Requirements (CMMI).
 - **Bugs**: Includes bugs filed as part of test execution and any work items that belong to the bug Category that links to the test case.
  
 :::image type="content" source="media/navigate/view-linked-items.png" alt-text="Define tab, View linked items dialog.":::


### PR DESCRIPTION
Documentation has a minor discrepancy fro the product truth. As "custom work item type" is not supported. So I have removed this part to not confuse customers. 

@chcomley  can you please merge/ approve the change? 

Thank you :) 