### PR TITLE
Clarify sprint-257 that stageList can only be used for base YAML and not for templates 

### DIFF
--- a/release-notes/2025/includes/pipelines/sprint-257-update.md
+++ b/release-notes/2025/includes/pipelines/sprint-257-update.md
@@ -113,6 +113,8 @@ When queuing this pipeline, you have the option of choosing multiple regions to 
 > [!div class="mx-imgBorder"]
 > [![Screenshot of Run pipeline region multi selection.](../../media/257-pipelines-08.png "Screenshot of Run pipeline region multi selection.")](../../media/257-pipelines-08.png#lightbox)
 
+Please note that `stageList` cannot be used on templates. For templates, please leverage the `Object` data type instead.
+
 ### See the full YAML code of a pipeline run
 
 YAML pipelines are composable. You may extend a template, to ensure your pipelines runs the necessary static analysis tools, and include templates to run common stages or jobs or tasks.


### PR DESCRIPTION
This warning is available at https://learn.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters?view=azure-devops#parameter-data-types but not on the release notes.