### PR TITLE
Added note to include 1 file in parent folder so that contents inside subfolder show up in wiki.

### DIFF
--- a/docs/project/wiki/wiki-file-structure.md
+++ b/docs/project/wiki/wiki-file-structure.md
@@ -48,6 +48,20 @@ The file name for each wiki page corresponds to the wiki page title. In the file
 
 The _.order_ file defines the wiki page sequence. Git looks for this file in each folder to identify the sequence to present files at that location. The default page sequence is alphabetical order (A to Z) by file name.
 
+> [!IMPORTANT]
+> If a parent folder contains only subfolders and no files of its own, the wiki will display the parent folder as blank—even if the subfolders contain markdown files. To ensure that markdown files within subfolders are visible, always include at least one file (such as a .order file or any other file with content) in the parent folder.
+
+```
+|- parent-folder
+|-- sub-folder1
+|   |-- file1.md
+|   |-- file2.md
+|-- sub-folder2
+|   |-- file3.md
+|   |-- file4.md
+|-- .order
+```
+
 ### Define custom page sequence
 
 When a folder doesn't have an _.order_ file, Git uses the default alphabetical sequence.

--- a/docs/project/wiki/wiki-file-structure.md
+++ b/docs/project/wiki/wiki-file-structure.md
@@ -8,7 +8,7 @@ ms.topic: concept-article
 ms.author: chcomley
 ms.reviewer: gopinach
 author: chcomley
-ms.date: 05/29/2025
+ms.date: 09/25/2025
 #customer intent: As an Azure DevOps developer, I want to understand the wiki file and folder structure in the Git repository, so I can follow the naming and location conventions.
 ---
 
@@ -49,18 +49,18 @@ The file name for each wiki page corresponds to the wiki page title. In the file
 The _.order_ file defines the wiki page sequence. Git looks for this file in each folder to identify the sequence to present files at that location. The default page sequence is alphabetical order (A to Z) by file name.
 
 > [!IMPORTANT]
-> If a parent folder contains only subfolders and no files of its own, the wiki will display the parent folder as blank—even if the subfolders contain markdown files. To ensure that markdown files within subfolders are visible, always include at least one file (such as a .order file or any other file with content) in the parent folder.
-
-```
-|- parent-folder
-|-- sub-folder1
-|   |-- file1.md
-|   |-- file2.md
-|-- sub-folder2
-|   |-- file3.md
-|   |-- file4.md
-|-- .order
-```
+> When a parent folder contains only subfolders and no files of its own, the wiki displays the parent folder as blank—even if the subfolders include markdown files. To ensure visibility of markdown files within subfolders, always place at least one file (such as a `.order` file or any other file with content) in the parent folder.
+>
+>```
+>|- parent-folder
+>|-- sub-folder1
+>|   |-- file1.md
+>|   |-- file2.md
+>|-- sub-folder2
+>|   |-- file3.md
+>|   |-- file4.md
+>|-- .order
+>```
 
 ### Define custom page sequence
 


### PR DESCRIPTION
Added a note to clarify that the parent folder must contain at least one file (e.g., a .order file) to ensure that markdown files within subfolders are displayed in the wiki. If the parent folder has no content, only its name will appear in the wiki, and the subfolder contents will not be shown.