### PR TITLE
Document `AZP_AGENT_DEFAULT_MAP_DOCKER_SOCKET_TO_FALSE` @ container proc

### DIFF
--- a/docs/pipelines/process/container-phases.md
+++ b/docs/pipelines/process/container-phases.md
@@ -151,8 +151,7 @@ resources:
     mapDockerSocket: true
 ```
 
-For managing mass-deployments needing Docker-in-container, it may be more convenient to set the `AZP_AGENT_DEFAULT_MAP_DOCKER_SOCKET_TO_FALSE=false` environment variable short term, that reverts the agent to the old behavior rather than having to duplicate this change across many places.
-
+For large-scale deployments where updating YAML everywhere is impractical, you can temporarily set the agent host environment variable `AZP_AGENT_DEFAULT_MAP_DOCKER_SOCKET_TO_FALSE=false` to restore the previous default behavior (mounting `/var/run/docker.sock` into Linux container jobs). Use this only as a short-term mitigation, as it re-enables Docker socket mapping by default.
 > [!CAUTION]
 > Mapping the Docker socket has serious security implications. Code inside the container can run as root on your Docker host. Only set `mapDockerSocket: true` when your job requires Docker-in-container behavior.
 

--- a/docs/pipelines/process/container-phases.md
+++ b/docs/pipelines/process/container-phases.md
@@ -2,7 +2,7 @@
 title: YAML pipeline container jobs
 description: Learn about configuring and running Azure Pipelines YAML pipeline jobs inside containers.
 ms.topic: concept-article
-ms.date: 08/14/2026
+ms.date: 09/09/2026
 monikerRange: "<=azure-devops"
 #customer intent: As an Azure Pipelines builder and tester, I want to learn about running pipeline jobs in containers so I can build and test pipelines in various agent configurations.
 ---
@@ -151,7 +151,8 @@ resources:
     mapDockerSocket: true
 ```
 
-For large-scale deployments where updating YAML everywhere is impractical, you can temporarily set the agent host environment variable `AZP_AGENT_DEFAULT_MAP_DOCKER_SOCKET_TO_FALSE=false` to restore the previous default behavior (mounting `/var/run/docker.sock` into Linux container jobs). Use this only as a short-term mitigation, as it re-enables Docker socket mapping by default.
+For large-scale deployments where updating YAML everywhere is impractical, you can temporarily set the agent host environment variable `AZP_AGENT_DEFAULT_MAP_DOCKER_SOCKET_TO_FALSE=false` to restore the previous default behavior, where Linux container jobs map `/var/run/docker.sock` unless `mapDockerSocket` is explicitly configured. Use this only as a short-term mitigation, as it re-enables Docker socket mapping by default.
+
 > [!CAUTION]
 > Mapping the Docker socket has serious security implications. Code inside the container can run as root on your Docker host. Only set `mapDockerSocket: true` when your job requires Docker-in-container behavior.
 

--- a/docs/pipelines/process/container-phases.md
+++ b/docs/pipelines/process/container-phases.md
@@ -151,6 +151,8 @@ resources:
     mapDockerSocket: true
 ```
 
+For managing mass-deployments needing Docker-in-container, it may be more convenient to set the `AZP_AGENT_DEFAULT_MAP_DOCKER_SOCKET_TO_FALSE=false` environment variable short term, that reverts the agent to the old behavior rather than having to duplicate this change across many places.
+
 > [!CAUTION]
 > Mapping the Docker socket has serious security implications. Code inside the container can run as root on your Docker host. Only set `mapDockerSocket: true` when your job requires Docker-in-container behavior.
 


### PR DESCRIPTION
This is useful short-term for mass-deployments when it's impractical and unrealistic to make large changes on suddenly-updated agents.

This env var toggle has been added in the same PR https://github.com/microsoft/azure-pipelines-agent/pull/5627, but it looks that the docs writers had forgotten to record this change for better discovery.